### PR TITLE
Fixed typo on 'content not organised header'

### DIFF
--- a/test-cases.html
+++ b/test-cases.html
@@ -106,9 +106,9 @@
 <div style="float:right; width:33%">Cleanse</div></div>
   </div>
   
-  <h3 class="heading-medium" id="content-content-is-not-organised-into-into-well-defined-groups-or-chunks-using-headings,-lists,-and-other-visual-mechanisms">
+  <h3 class="heading-medium" id="content-content-is-not-organised-into-well-defined-groups-or-chunks-using-headings,-lists,-and-other-visual-mechanisms">
     <a href="tests/content-content-is-not-organised-into-into-well-defined-groups-or-chunks-using-headings,-lists,-and-other-visual-mechanisms.html">
-      Content is not organised into into well-defined groups or chunks, using headings, lists, and other visual mechanisms
+      Content is not organised into well-defined groups or chunks, using headings, lists, and other visual mechanisms
     </a>
   </h3>
 


### PR DESCRIPTION
Content is not organised into into well-defined groups or chunks, using headings, lists, and other visual mechanisms. 

Removed additional 'into'