### PR TITLE
Update Asqatasun results

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -11,9 +11,9 @@
       "false-positive": 2
     },
     "tenon": {
-      "notfound": 89,
+      "notfound": 88,
       "error": 53,
-      "warning": 0,
+      "warning": 1,
       "manual": 0,
       "different": 1,
       "identified": 0,
@@ -51,8 +51,8 @@
       "false-positive": 0
     },
     "asqatasun": {
-      "notfound": 81,
-      "error": 38,
+      "notfound": 78,
+      "error": 41,
       "warning": 0,
       "manual": 21,
       "different": 3,
@@ -121,12 +121,12 @@
       },
       "tenon": {
         "detectable": {
-          "error_warning": 52,
-          "error_warning_manual": 52
+          "error_warning": 53,
+          "error_warning_manual": 53
         },
         "total": {
-          "error_warning": 37,
-          "error_warning_manual": 37
+          "error_warning": 38,
+          "error_warning_manual": 38
         }
       },
       "wave": {
@@ -161,12 +161,12 @@
       },
       "asqatasun": {
         "detectable": {
-          "error_warning": 38,
-          "error_warning_manual": 58
+          "error_warning": 41,
+          "error_warning_manual": 61
         },
         "total": {
-          "error_warning": 27,
-          "error_warning_manual": 41
+          "error_warning": 29,
+          "error_warning_manual": 43
         }
       },
       "sortsite": {
@@ -216,8 +216,8 @@
       {
         "position": 1,
         "name": "tenon",
-        "error_warning": 37,
-        "error_warning_manual": 37
+        "error_warning": 38,
+        "error_warning_manual": 38
       },
       {
         "position": 2,
@@ -227,21 +227,21 @@
       },
       {
         "position": 3,
+        "name": "asqatasun",
+        "error_warning": 29,
+        "error_warning_manual": 43
+      },
+      {
+        "position": 4,
         "name": "wave",
         "error_warning": 27,
         "error_warning_manual": 29
       },
       {
-        "position": 4,
+        "position": 5,
         "name": "axe",
         "error_warning": 27,
         "error_warning_manual": 27
-      },
-      {
-        "position": 5,
-        "name": "asqatasun",
-        "error_warning": 27,
-        "error_warning_manual": 41
       },
       {
         "position": 6,
@@ -278,14 +278,14 @@
       {
         "position": 1,
         "name": "asqatasun",
-        "error_warning": 27,
-        "error_warning_manual": 41
+        "error_warning": 29,
+        "error_warning_manual": 43
       },
       {
         "position": 2,
         "name": "tenon",
-        "error_warning": 37,
-        "error_warning_manual": 37
+        "error_warning": 38,
+        "error_warning_manual": 38
       },
       {
         "position": 3,

--- a/index.html
+++ b/index.html
@@ -50,14 +50,14 @@
       </p>
 
       <p>
-        The best performing tool in this category found 37% of the problems we introduced. Whereas the worst performing tool only picked up 9% of the barriers.
+        The best performing tool in this category found 38% of the problems we introduced. Whereas the worst performing tool only picked up 9% of the barriers.
       </p>
 
       <p>
         The second column of results takes into account potential barriers that tools noticed, but needed a human being to check, like whether alt text descriptions were accurate. A tool that flags things like this can help you pick up more issues overall.
       </p>
 
-      <p>The best performing tool in this category picked up 41% of our deliberate mistakes.</p>
+      <p>The best performing tool in this category picked up 43% of our deliberate mistakes.</p>
 
       <h3>How did each tool do?</h3>
 
@@ -73,12 +73,16 @@
         <tbody>
           <tr>
               <th>Tenon</th>
-              <td>37%</td>
-              <td>37%</td>
+              <td>38%</td>
+              <td>38%</td>
             </tr><tr>
               <th>AChecker</th>
               <td>31%</td>
               <td>32%</td>
+            </tr><tr>
+              <th>Asqatasun</th>
+              <td>29%</td>
+              <td>43%</td>
             </tr><tr>
               <th>WAVE</th>
               <td>27%</td>
@@ -87,10 +91,6 @@
               <th>aXe</th>
               <td>27%</td>
               <td>27%</td>
-            </tr><tr>
-              <th>Asqatasun</th>
-              <td>27%</td>
-              <td>41%</td>
             </tr><tr>
               <th>SortSite</th>
               <td>27%</td>

--- a/results.html
+++ b/results.html
@@ -45,7 +45,7 @@
     </div>
 
     <div class="data column-third">
-      <span class="data-item bold-xxlarge">37%</span>
+      <span class="data-item bold-xxlarge">38%</span>
       <span class="data-item bold-xsmall">most issues found by a tool</span>
     </div>
   </div>
@@ -989,8 +989,8 @@
               <td class="notfound">
                 Not found
               </td>
-              <td class="notfound">
-                Not found
+              <td class="error">
+                Issue found
               </td>
               <td class="notfound">
                 Not found
@@ -1333,8 +1333,8 @@
               <td class="notfound">
                 Not found
               </td>
-              <td class="notfound">
-                Not found
+              <td class="error">
+                Issue found
               </td>
               <td class="notfound">
                 Not found
@@ -3169,8 +3169,8 @@
               <td class="notfound">
                 Not found
               </td>
-              <td class="notfound">
-                Not found
+              <td class="error">
+                Issue found
               </td>
               <td class="notfound">
                 Not found

--- a/tests.json
+++ b/tests.json
@@ -327,7 +327,7 @@
       "example": "<a href=\"example-pages/empty.html\">Example page with an empty lang attribute</a>",
       "results": {
         "google": "error",
-        "asqatasun": "notfound",
+        "asqatasun": "error",
         "tenon": "notfound",
         "wave": "notfound",
         "sortsite": "notfound",
@@ -464,7 +464,7 @@
       "example": "<a href=\"example-pages/empty.html\">Example page with a empty page title</a>",
       "results": {
         "google": "error",
-        "asqatasun": "notfound",
+        "asqatasun": "error",
         "tenon": "error",
         "wave": "notfound",
         "sortsite": "notfound",
@@ -1196,7 +1196,7 @@
       "example": "        Visit the GOV.UK website <a href=\"https://www.gov.uk/\">.</a>",
       "results": {
         "google": "error",
-        "asqatasun": "notfound",
+        "asqatasun": "error",
         "tenon": "notfound",
         "wave": "notfound",
         "sortsite": "notfound",


### PR DESCRIPTION
Some test case results for Asqatasun were incorrectly identified as "Not found".
We retested the 3 issues pointed out to us in #5 and found all of them correctly report an error:

* Link contains only a full stop
* html element has an empty lang attribute
* Empty page title