### PR TITLE
Fix links to raw data on GitHub

### DIFF
--- a/build/templates/results.html
+++ b/build/templates/results.html
@@ -196,9 +196,9 @@
   <h2>Want more detail?</h2>
   <p>
     Have a look at the 
-    <a href="https://github.com/alphagov/accessibility-tool-audit/blob/master/tests.json">raw data</a>
+    <a href="https://github.com/alphagov/accessibility-tool-audit/blob/gh-pages/tests.json">raw data</a>
     and 
-    <a href="https://github.com/alphagov/accessibility-tool-audit/blob/master/analysis.json">analysis</a>.
+    <a href="https://github.com/alphagov/accessibility-tool-audit/blob/gh-pages/analysis.json">analysis</a>.
   </p>
 
 </main>

--- a/results.html
+++ b/results.html
@@ -5640,9 +5640,9 @@
   <h2>Want more detail?</h2>
   <p>
     Have a look at the 
-    <a href="https://github.com/alphagov/accessibility-tool-audit/blob/master/tests.json">raw data</a>
+    <a href="https://github.com/alphagov/accessibility-tool-audit/blob/gh-pages/tests.json">raw data</a>
     and 
-    <a href="https://github.com/alphagov/accessibility-tool-audit/blob/master/analysis.json">analysis</a>.
+    <a href="https://github.com/alphagov/accessibility-tool-audit/blob/gh-pages/analysis.json">analysis</a>.
   </p>
 
 </main>


### PR DESCRIPTION
We removed the master branch and made the gh-pages branch the default.