### PR TITLE
Sticky results table header

### DIFF
--- a/assets/sass/application.scss
+++ b/assets/sass/application.scss
@@ -343,6 +343,13 @@ h3 {
 
 #results-table {
 
+  // Stick header for better viewing
+  thead {
+    background: white;
+    position: sticky;
+    top: 0;
+  }
+
   // Positive results
 
   $positive-colour: #43b93c;

--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -2551,6 +2551,12 @@ h3 {
   }
 }
 
+#results-table thead {
+  background: white;
+  position: sticky;
+  top: 0;
+}
+
 #results-table .error:before {
   content: "";
   background: #43b93c;


### PR DESCRIPTION
## What is this? 

First off, awesome work with this! Thank you for sharing :D

This makes the full results table header stick once you scroll past it. 

![2017-05-08 19 34 48](https://cloud.githubusercontent.com/assets/2072894/25830836/73afdc4a-3425-11e7-9ced-cb0357bd621a.gif)

[You can view it live from my fork too](https://robdel12.github.io/accessibility-tool-audit/results.html)

