### PR TITLE
Update cost of Tenon

### DIFF
--- a/build/templates/index.html
+++ b/build/templates/index.html
@@ -181,8 +181,8 @@
           </tr>
           <tr>
             <th scope="row">Tenon</th>
-            <td>Free</td>
-            <td>$9/month</td>
+            <td>Free trial</td>
+            <td>$47/month</td>
             <td>No</td>
             <td>Yes</td>
             <td>Yes</td>

--- a/index.html
+++ b/index.html
@@ -232,8 +232,8 @@
           </tr>
           <tr>
             <th scope="row">Tenon</th>
-            <td>Free</td>
-            <td>$9/month</td>
+            <td>Free trial</td>
+            <td>$47/month</td>
             <td>No</td>
             <td>Yes</td>
             <td>Yes</td>


### PR DESCRIPTION
Tenon has increased its cost and is no longer free, but it still offers a free trial. See https://tenon.io/pricing.php
You can still use their service for free but only for 4 URLs. After that you will be prompted to register.