### PR TITLE
Update test results for Nu Html Checker

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -91,10 +91,10 @@
       "false-positive": 0
     },
     "nu": {
-      "notfound": 129,
-      "error": 13,
-      "warning": 0,
-      "manual": 0,
+      "notfound": 119,
+      "error": 18,
+      "warning": 1,
+      "manual": 4,
       "different": 0,
       "identified": 0,
       "wrong": 0,
@@ -201,12 +201,12 @@
       },
       "nu": {
         "detectable": {
-          "error_warning": 13,
-          "error_warning_manual": 13
+          "error_warning": 19,
+          "error_warning_manual": 23
         },
         "total": {
-          "error_warning": 9,
-          "error_warning_manual": 9
+          "error_warning": 13,
+          "error_warning_manual": 16
         }
       }
     }
@@ -270,8 +270,8 @@
       {
         "position": 10,
         "name": "nu",
-        "error_warning": 9,
-        "error_warning_manual": 9
+        "error_warning": 13,
+        "error_warning_manual": 16
       }
     ],
     "by_error_warning_manual": [
@@ -332,8 +332,8 @@
       {
         "position": 10,
         "name": "nu",
-        "error_warning": 9,
-        "error_warning_manual": 9
+        "error_warning": 13,
+        "error_warning_manual": 16
       }
     ]
   }

--- a/changelog.json
+++ b/changelog.json
@@ -3,6 +3,11 @@
   "changelog": [
     {
       "date": "5 December 2017",
+      "text": "Re-tested and updated 11 results on Nu Html Checker",
+      "link": "https://github.com/alphagov/accessibility-tool-audit/pull/22"
+    },
+    {
+      "date": "5 December 2017",
       "text": "Re-tested and updated 30 results on HTML_CodeSniffer",
       "link": "https://github.com/alphagov/accessibility-tool-audit/pull/21"
     },

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       </p>
 
       <p>
-        The best performing tool in this category found 37% of the problems we introduced. Whereas the worst performing tool only picked up 9% of the barriers.
+        The best performing tool in this category found 37% of the problems we introduced. Whereas the worst performing tool only picked up 13% of the barriers.
       </p>
 
       <p>
@@ -109,8 +109,8 @@
               <td>16%</td>
             </tr><tr>
               <th>Nu Html Checker</th>
-              <td>9%</td>
-              <td>9%</td>
+              <td>13%</td>
+              <td>16%</td>
             </tr>
         </tbody>
       </table>

--- a/results.html
+++ b/results.html
@@ -714,8 +714,8 @@
               <td class="error">
                 Issue found
               </td>
-              <td class="notfound">
-                Not found
+              <td class="error">
+                Issue found
               </td>
             </tr>
           
@@ -790,8 +790,8 @@
               <td class="error">
                 Issue found
               </td>
-              <td class="notfound">
-                Not found
+              <td class="error">
+                Issue found
               </td>
             </tr>
           
@@ -1096,8 +1096,8 @@
               <td class="error">
                 Issue found
               </td>
-              <td class="notfound">
-                Not found
+              <td class="error">
+                Issue found
               </td>
             </tr>
           
@@ -1326,8 +1326,8 @@
               <td class="notfound">
                 Not found
               </td>
-              <td class="notfound">
-                Not found
+              <td class="error">
+                Issue found
               </td>
             </tr>
           
@@ -1364,8 +1364,8 @@
               <td class="error">
                 Issue found
               </td>
-              <td class="notfound">
-                Not found
+              <td class="error">
+                Issue found
               </td>
             </tr>
           
@@ -1404,8 +1404,8 @@
               <td class="error">
                 Issue found
               </td>
-              <td class="error">
-                Issue found
+              <td class="warning">
+                Warning only
               </td>
             </tr>
           
@@ -1902,8 +1902,8 @@
               <td class="notfound">
                 Not found
               </td>
-              <td class="notfound">
-                Not found
+              <td class="error">
+                Issue found
               </td>
             </tr>
           
@@ -2360,8 +2360,8 @@
               <td class="warning">
                 Warning only
               </td>
-              <td class="notfound">
-                Not found
+              <td class="manual">
+                User to check
               </td>
             </tr>
           
@@ -2398,8 +2398,8 @@
               <td class="warning">
                 Warning only
               </td>
-              <td class="notfound">
-                Not found
+              <td class="manual">
+                User to check
               </td>
             </tr>
           
@@ -2436,8 +2436,8 @@
               <td class="warning">
                 Warning only
               </td>
-              <td class="notfound">
-                Not found
+              <td class="manual">
+                User to check
               </td>
             </tr>
           
@@ -2474,8 +2474,8 @@
               <td class="manual">
                 User to check
               </td>
-              <td class="notfound">
-                Not found
+              <td class="manual">
+                User to check
               </td>
             </tr>
           
@@ -5583,6 +5583,13 @@
   <h2 id="changelog">Changelog</h2>
 
   <ol class="summary-data">
+    
+      <li>
+        <time class="timestamp">5 December 2017</time>
+        
+          <a href="https://github.com/alphagov/accessibility-tool-audit/pull/22">Re-tested and updated 11 results on Nu Html Checker</a>
+        
+      </li>
     
       <li>
         <time class="timestamp">5 December 2017</time>

--- a/tests.json
+++ b/tests.json
@@ -228,7 +228,7 @@
         "codesniffer": "error",
         "achecker": "error",
         "eiii": "error",
-        "nu": "notfound"
+        "nu": "error"
       }
     },
     "Italics used on long sections of text": {
@@ -258,7 +258,7 @@
         "codesniffer": "notfound",
         "achecker": "error",
         "eiii": "error",
-        "nu": "notfound"
+        "nu": "error"
       }
     },
     "Long lines of text": {
@@ -380,7 +380,7 @@
         "codesniffer": "notfound",
         "achecker": "error",
         "eiii": "error",
-        "nu": "notfound"
+        "nu": "error"
       }
     },
     "lang attribute used to identify change of language, but with invalid value": {
@@ -472,7 +472,7 @@
         "codesniffer": "error",
         "achecker": "notfound",
         "eiii": "error",
-        "nu": "notfound"
+        "nu": "error"
       }
     },
     "Missing page title": {
@@ -487,7 +487,7 @@
         "codesniffer": "error",
         "achecker": "error",
         "eiii": "error",
-        "nu": "notfound"
+        "nu": "error"
       }
     }
   },
@@ -504,7 +504,7 @@
         "codesniffer": "error",
         "achecker": "error",
         "eiii": "error",
-        "nu": "error"
+        "nu": "warning"
       }
     },
     "Missing H1": {
@@ -703,7 +703,7 @@
         "codesniffer": "manual",
         "achecker": "notfound",
         "eiii": "notfound",
-        "nu": "notfound"
+        "nu": "error"
       }
     },
     "Table that only has TH elements in it": {
@@ -885,7 +885,7 @@
         "codesniffer": "warning",
         "achecker": "warning",
         "eiii": "notfound",
-        "nu": "notfound"
+        "nu": "manual"
       }
     },
     "Image that conveys information has inappropriate alt text": {
@@ -900,7 +900,7 @@
         "codesniffer": "manual",
         "achecker": "warning",
         "eiii": "notfound",
-        "nu": "notfound"
+        "nu": "manual"
       }
     },
     "Image alt attribute contains image file name": {
@@ -915,7 +915,7 @@
         "codesniffer": "manual",
         "achecker": "warning",
         "eiii": "notfound",
-        "nu": "notfound"
+        "nu": "manual"
       }
     },
     "Image with partial text alternative": {
@@ -930,7 +930,7 @@
         "codesniffer": "manual",
         "achecker": "manual",
         "eiii": "notfound",
-        "nu": "notfound"
+        "nu": "manual"
       }
     }
   },


### PR DESCRIPTION
I have re-tested all of our test cases on 23 November 2017 with Nu Html Checker and updated the results accordingly.
11 entries changed as a result of that, nearly all to the better. I used the "show image report" feature, that's why a couple of tests around the alt parameter were changed to "user to test".
That changed the overall barriers from 9%/9% to 13%/16%.
