### PR TITLE
 Enclose all form elements in a form tag

### DIFF
--- a/test-cases.html
+++ b/test-cases.html
@@ -1327,12 +1327,12 @@ pets</td>
   </h3>
 
   <div class="example">
-    <label for="missing-labels-day">Your child's date of birth</label>
+    <form><label for="missing-labels-day">Your child's date of birth</label>
 <p>
 <input id="missing-labels-day" type="text"/>
 <input id="missing-labels-month" type="text"/>
 <input id="missing-labels-year" type="text"/>
-</p>
+</p></form>
   </div>
   
   <h3 class="heading-medium" id="forms-error-messages-no-suggestion-for-corrections-given-e.g.-required-format">
@@ -1342,11 +1342,11 @@ pets</td>
   </h3>
 
   <div class="example">
-    <label class="required-format-not-given">
+    <form><label class="required-format-not-given">
             Phone number
             <span class="error-message">is not valid</span>
 <input class="has-errors" pattern="7[0-9]{9}" required="" type="tel"/>
-</label>
+</label></form>
   </div>
   
   <h3 class="heading-medium" id="forms-left-aligned-form-labels-with-too-much-white-space">
@@ -1356,10 +1356,10 @@ pets</td>
   </h3>
 
   <div class="example">
-    <p class="too-much-whitespace">
+    <form><p class="too-much-whitespace">
 <label for="input-too-far-away">Country</label>
 <input id="input-too-far-away" type="text"/>
-</p>
+</p></form>
   </div>
   
   <h3 class="heading-medium" id="forms-group-of-radio-buttons-not-enclosed-in-a-fieldset">
@@ -1369,7 +1369,7 @@ pets</td>
   </h3>
 
   <div class="example">
-    <h4>Do you already have a personal user account?</h4>
+    <form><h4>Do you already have a personal user account?</h4>
 <label class="block-label" for="radio-inline-1">
 <input id="radio-inline-1" name="radio-inline-group" type="radio" value="Yes" />
             Yes
@@ -1377,7 +1377,7 @@ pets</td>
 <label class="block-label" for="radio-inline-2">
 <input id="radio-inline-2" name="radio-inline-group" type="radio" value="No" />
             No
-        </label>
+        </label></form>
   </div>
   
   <h3 class="heading-medium" id="forms-form-element-has-no-label">
@@ -1387,7 +1387,7 @@ pets</td>
   </h3>
 
   <div class="example">
-    <input type="text" />
+    <form><input type="text" /></form>
   </div>
   
   <h3 class="heading-medium" id="forms-fieldset-without-a-legend">
@@ -1397,9 +1397,9 @@ pets</td>
   </h3>
 
   <div class="example">
-    <fieldset>
+    <form><fieldset>
             I am a fieldset without a legend
-        </fieldset>
+        </fieldset></form>
   </div>
   
   <h3 class="heading-medium" id="forms-empty-legend">
@@ -1409,9 +1409,9 @@ pets</td>
   </h3>
 
   <div class="example">
-    <fieldset>
+    <form><fieldset>
 <legend></legend>
-</fieldset>
+</fieldset></form>
   </div>
   
   <h3 class="heading-medium" id="forms-label-element-with-for-attribute-but-not-matching-id=-attribute-of-form-control">
@@ -1421,11 +1421,11 @@ pets</td>
   </h3>
 
   <div class="example">
-    <fieldset>
+    <form><fieldset>
 <legend>Non-matching for attribute</legend>
 <label id="not-matching-anything">form</label>
 <input id="label-for-not-matching" type="checkbox" value="yes"/>
-</fieldset>
+</fieldset></form>
   </div>
   
   <h3 class="heading-medium" id="forms-group-of-check-boxes-not-enclosed-in-a-fieldset">
@@ -1435,7 +1435,7 @@ pets</td>
   </h3>
 
   <div class="example">
-    <h4>Which types of waste do you transport regularly?</h4>
+    <form><h4>Which types of waste do you transport regularly?</h4>
 <label class="block-label" for="waste-type-1">
 <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal" />
             Waste from animal carcasses
@@ -1447,7 +1447,7 @@ pets</td>
 <label class="block-label" for="waste-type-3">
 <input id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm-agricultural" />
             Farm or agricultural waste
-        </label>
+        </label></form>
   </div>
   
   <h3 class="heading-medium" id="forms-empty-label-found">
@@ -1457,8 +1457,8 @@ pets</td>
   </h3>
 
   <div class="example">
-    <label for="empty"></label>
-<input id="empty" type="text" value="" />
+    <form><label for="empty"></label>
+<input id="empty" type="text" value="" /></form>
   </div>
   
   <h3 class="heading-medium" id="forms-two-unique-labels-but-identical-for=-attributes">
@@ -1468,7 +1468,7 @@ pets</td>
   </h3>
 
   <div class="example">
-    <label for="two-labels-day">Date of issue</label>
+    <form><label for="two-labels-day">Date of issue</label>
 <p>
 <label for="two-labels-day">Day</label>
 <input id="two-labels-day" type="text"/>
@@ -1476,7 +1476,7 @@ pets</td>
 <input id="two-labels-month" type="text"/>
 <label for="two-labels-year">Year</label>
 <input id="two-labels-year" type="text"/>
-</p>
+</p></form>
   </div>
   
   <h3 class="heading-medium" id="forms-errors-identified-with-a-poor-colour-contrast">
@@ -1512,10 +1512,10 @@ pets</td>
   </h3>
 
   <div class="example">
-    <label for="x_3">Name
+    <form><label for="x_3">Name
             <input id="x_3" name="x_3" type="text" /></label><br />
 <label for="x_4">Name
-            <input id="x_4" name="x_4" type="text" /></label>
+            <input id="x_4" name="x_4" type="text" /></label></form>
   </div>
   
   <h3 class="heading-medium" id="forms-missing-labels-in-checkboxes">
@@ -1525,7 +1525,7 @@ pets</td>
   </h3>
 
   <div class="example">
-    <fieldset>
+    <form><fieldset>
 <legend>What is your nationality?</legend>
 <label>British (including English, Scottish, Welsh and Northern Irish)</label>
 <input id="nationality_british" name="nationality.british" type="checkbox" value="true" />
@@ -1533,7 +1533,7 @@ pets</td>
 <input id="nationality_irish" name="nationality.irish" type="checkbox" value="true" />
 <label>Citizen of a different country</label>
 <input id="nationality_hasOtherCountry" name="nationality.hasOtherCountry" type="checkbox" value="true" />
-</fieldset>
+</fieldset></form>
   </div>
   
   <h3 class="heading-medium" id="forms-field-hint-not-associated-with-input">
@@ -1543,11 +1543,11 @@ pets</td>
   </h3>
 
   <div class="example">
-    <label class="form-label" for="ni-number">
+    <form><label class="form-label" for="ni-number">
             National Insurance number
         </label>
 <p class="form-hint">It'll be on your last payslip. For example, JH 21 90 0A.</p>
-<input class="form-control" id="ni-number" type="text" />
+<input class="form-control" id="ni-number" type="text" /></form>
   </div>
   
   <h3 class="heading-medium" id="forms-placeholder-no-label">
@@ -1557,8 +1557,8 @@ pets</td>
   </h3>
 
   <div class="example">
-    <input id="search-main" name="q" placeholder="Search" type="search" />
-<input class="submit" type="submit" value="Search" />
+    <form><input id="search-main" name="q" placeholder="Search" type="search" />
+<input class="submit" type="submit" value="Search" /></form>
   </div>
   
   <h3 class="heading-medium" id="forms-errors-are-not-identified">
@@ -1594,13 +1594,13 @@ pets</td>
   </h3>
 
   <div class="example">
-    <label for="language-selector">Select your language</label>
+    <form><label for="language-selector">Select your language</label>
 <select class="language-selector" id="language-selector">
 <option value="">Change your language</option>
 <option value="en">English</option>
 <option value="de">German</option>
 <option value="fr">French</option>
-</select>
+</select></form>
   </div>
   
   <h2 id="navigation" class="heading-large">Navigation</h2>

--- a/tests.json
+++ b/tests.json
@@ -1451,7 +1451,7 @@
       }
     },
     "Labels missing when they would look clumsy for some form controls": {
-      "example": "<label for=\"missing-labels-day\">Your child's date of birth</label>\n<p>\n<input id=\"missing-labels-day\" type=\"text\"/>\n<input id=\"missing-labels-month\" type=\"text\"/>\n<input id=\"missing-labels-year\" type=\"text\"/>\n</p>",
+      "example": "<form><label for=\"missing-labels-day\">Your child's date of birth</label>\n<p>\n<input id=\"missing-labels-day\" type=\"text\"/>\n<input id=\"missing-labels-month\" type=\"text\"/>\n<input id=\"missing-labels-year\" type=\"text\"/>\n</p></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
@@ -1467,7 +1467,7 @@
       }
     },
     "Error messages - no suggestion for corrections given, e.g. required format": {
-      "example": "<label class=\"required-format-not-given\">\n            Phone number\n            <span class=\"error-message\">is not valid</span>\n<input class=\"has-errors\" pattern=\"7[0-9]{9}\" required=\"\" type=\"tel\"/>\n</label>",
+      "example": "<form><label class=\"required-format-not-given\">\n            Phone number\n            <span class=\"error-message\">is not valid</span>\n<input class=\"has-errors\" pattern=\"7[0-9]{9}\" required=\"\" type=\"tel\"/>\n</label></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
@@ -1483,7 +1483,7 @@
       }
     },
     "Left aligned form labels with too much white space": {
-      "example": "<p class=\"too-much-whitespace\">\n<label for=\"input-too-far-away\">Country</label>\n<input id=\"input-too-far-away\" type=\"text\"/>\n</p>",
+      "example": "<form><p class=\"too-much-whitespace\">\n<label for=\"input-too-far-away\">Country</label>\n<input id=\"input-too-far-away\" type=\"text\"/>\n</p></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
@@ -1499,7 +1499,7 @@
       }
     },
     "Group of radio buttons not enclosed in a fieldset": {
-      "example": "<h4>Do you already have a personal user account?</h4>\n<label class=\"block-label\" for=\"radio-inline-1\">\n<input id=\"radio-inline-1\" name=\"radio-inline-group\" type=\"radio\" value=\"Yes\" />\n            Yes\n        </label><br/>\n<label class=\"block-label\" for=\"radio-inline-2\">\n<input id=\"radio-inline-2\" name=\"radio-inline-group\" type=\"radio\" value=\"No\" />\n            No\n        </label>",
+      "example": "<form><h4>Do you already have a personal user account?</h4>\n<label class=\"block-label\" for=\"radio-inline-1\">\n<input id=\"radio-inline-1\" name=\"radio-inline-group\" type=\"radio\" value=\"Yes\" />\n            Yes\n        </label><br/>\n<label class=\"block-label\" for=\"radio-inline-2\">\n<input id=\"radio-inline-2\" name=\"radio-inline-group\" type=\"radio\" value=\"No\" />\n            No\n        </label></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
@@ -1515,7 +1515,7 @@
       }
     },
     "Form element has no label": {
-      "example": "<input type=\"text\" />",
+      "example": "<form><input type=\"text\" /></form>",
       "results": {
         "google": "error",
         "asqatasun": "error",
@@ -1531,7 +1531,7 @@
       }
     },
     "Fieldset without a legend": {
-      "example": "<fieldset>\n            I am a fieldset without a legend\n        </fieldset>",
+      "example": "<form><fieldset>\n            I am a fieldset without a legend\n        </fieldset></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "error",
@@ -1547,7 +1547,7 @@
       }
     },
     "Empty legend": {
-      "example": "<fieldset>\n<legend></legend>\n</fieldset>",
+      "example": "<form><fieldset>\n<legend></legend>\n</fieldset></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "error",
@@ -1563,7 +1563,7 @@
       }
     },
     "Label element with for= attribute but not matching id= attribute of form control": {
-      "example": "<fieldset>\n<legend>Non-matching for attribute</legend>\n<label id=\"not-matching-anything\">form</label>\n<input id=\"label-for-not-matching\" type=\"checkbox\" value=\"yes\"/>\n</fieldset>",
+      "example": "<form><fieldset>\n<legend>Non-matching for attribute</legend>\n<label id=\"not-matching-anything\">form</label>\n<input id=\"label-for-not-matching\" type=\"checkbox\" value=\"yes\"/>\n</fieldset></form>",
       "results": {
         "google": "error",
         "asqatasun": "error",
@@ -1579,7 +1579,7 @@
       }
     },
     "Group of check boxes not enclosed in a fieldset": {
-      "example": "<h4>Which types of waste do you transport regularly?</h4>\n<label class=\"block-label\" for=\"waste-type-1\">\n<input id=\"waste-type-1\" name=\"waste-types\" type=\"checkbox\" value=\"waste-animal\" />\n            Waste from animal carcasses\n        </label><br/>\n<label class=\"block-label\" for=\"waste-type-2\">\n<input id=\"waste-type-2\" name=\"waste-types\" type=\"checkbox\" value=\"waste-mines\" />\n            Waste from mines or quarries\n        </label><br/>\n<label class=\"block-label\" for=\"waste-type-3\">\n<input id=\"waste-type-3\" name=\"waste-types\" type=\"checkbox\" value=\"waste-farm-agricultural\" />\n            Farm or agricultural waste\n        </label>",
+      "example": "<form><h4>Which types of waste do you transport regularly?</h4>\n<label class=\"block-label\" for=\"waste-type-1\">\n<input id=\"waste-type-1\" name=\"waste-types\" type=\"checkbox\" value=\"waste-animal\" />\n            Waste from animal carcasses\n        </label><br/>\n<label class=\"block-label\" for=\"waste-type-2\">\n<input id=\"waste-type-2\" name=\"waste-types\" type=\"checkbox\" value=\"waste-mines\" />\n            Waste from mines or quarries\n        </label><br/>\n<label class=\"block-label\" for=\"waste-type-3\">\n<input id=\"waste-type-3\" name=\"waste-types\" type=\"checkbox\" value=\"waste-farm-agricultural\" />\n            Farm or agricultural waste\n        </label></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
@@ -1595,7 +1595,7 @@
       }
     },
     "Empty label found": {
-      "example": "<label for=\"empty\"></label>\n<input id=\"empty\" type=\"text\" value=\"\" />",
+      "example": "<form><label for=\"empty\"></label>\n<input id=\"empty\" type=\"text\" value=\"\" /></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
@@ -1611,7 +1611,7 @@
       }
     },
     "Two unique labels, but identical for= attributes": {
-      "example": "<label for=\"two-labels-day\">Date of issue</label>\n<p>\n<label for=\"two-labels-day\">Day</label>\n<input id=\"two-labels-day\" type=\"text\"/>\n<label for=\"two-labels-month\">Month</label>\n<input id=\"two-labels-month\" type=\"text\"/>\n<label for=\"two-labels-year\">Year</label>\n<input id=\"two-labels-year\" type=\"text\"/>\n</p>",
+      "example": "<form><label for=\"two-labels-day\">Date of issue</label>\n<p>\n<label for=\"two-labels-day\">Day</label>\n<input id=\"two-labels-day\" type=\"text\"/>\n<label for=\"two-labels-month\">Month</label>\n<input id=\"two-labels-month\" type=\"text\"/>\n<label for=\"two-labels-year\">Year</label>\n<input id=\"two-labels-year\" type=\"text\"/>\n</p></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
@@ -1643,7 +1643,7 @@
       }
     },
     "Non-unique field label found": {
-      "example": "<label for=\"x_3\">Name\n            <input id=\"x_3\" name=\"x_3\" type=\"text\" /></label><br />\n<label for=\"x_4\">Name\n            <input id=\"x_4\" name=\"x_4\" type=\"text\" /></label>",
+      "example": "<form><label for=\"x_3\">Name\n            <input id=\"x_3\" name=\"x_3\" type=\"text\" /></label><br />\n<label for=\"x_4\">Name\n            <input id=\"x_4\" name=\"x_4\" type=\"text\" /></label></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
@@ -1659,7 +1659,7 @@
       }
     },
     "Missing labels in checkboxes": {
-      "example": "<fieldset>\n<legend>What is your nationality?</legend>\n<label>British (including English, Scottish, Welsh and Northern Irish)</label>\n<input id=\"nationality_british\" name=\"nationality.british\" type=\"checkbox\" value=\"true\" />\n<label>Irish</label>\n<input id=\"nationality_irish\" name=\"nationality.irish\" type=\"checkbox\" value=\"true\" />\n<label>Citizen of a different country</label>\n<input id=\"nationality_hasOtherCountry\" name=\"nationality.hasOtherCountry\" type=\"checkbox\" value=\"true\" />\n</fieldset>",
+      "example": "<form><fieldset>\n<legend>What is your nationality?</legend>\n<label>British (including English, Scottish, Welsh and Northern Irish)</label>\n<input id=\"nationality_british\" name=\"nationality.british\" type=\"checkbox\" value=\"true\" />\n<label>Irish</label>\n<input id=\"nationality_irish\" name=\"nationality.irish\" type=\"checkbox\" value=\"true\" />\n<label>Citizen of a different country</label>\n<input id=\"nationality_hasOtherCountry\" name=\"nationality.hasOtherCountry\" type=\"checkbox\" value=\"true\" />\n</fieldset></form>",
       "results": {
         "google": "error",
         "asqatasun": "error",
@@ -1675,7 +1675,7 @@
       }
     },
     "Field hint not associated with input": {
-      "example": "<label class=\"form-label\" for=\"ni-number\">\n            National Insurance number\n        </label>\n<p class=\"form-hint\">It'll be on your last payslip. For example, JH 21 90 0A.</p>\n<input class=\"form-control\" id=\"ni-number\" type=\"text\" />",
+      "example": "<form><label class=\"form-label\" for=\"ni-number\">\n            National Insurance number\n        </label>\n<p class=\"form-hint\">It'll be on your last payslip. For example, JH 21 90 0A.</p>\n<input class=\"form-control\" id=\"ni-number\" type=\"text\" /></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
@@ -1691,7 +1691,7 @@
       }
     },
     "Placeholder no label": {
-      "example": "<input id=\"search-main\" name=\"q\" placeholder=\"Search\" type=\"search\" />\n<input class=\"submit\" type=\"submit\" value=\"Search\" />",
+      "example": "<form><input id=\"search-main\" name=\"q\" placeholder=\"Search\" type=\"search\" />\n<input class=\"submit\" type=\"submit\" value=\"Search\" /></form>",
       "results": {
         "google": "error",
         "asqatasun": "error",
@@ -1723,7 +1723,7 @@
       }
     },
     "Form control that changes context without warning": {
-      "example": "<label for=\"language-selector\">Select your language</label>\n<select class=\"language-selector\" id=\"language-selector\">\n<option value=\"\">Change your language</option>\n<option value=\"en\">English</option>\n<option value=\"de\">German</option>\n<option value=\"fr\">French</option>\n</select>",
+      "example": "<form><label for=\"language-selector\">Select your language</label>\n<select class=\"language-selector\" id=\"language-selector\">\n<option value=\"\">Change your language</option>\n<option value=\"en\">English</option>\n<option value=\"de\">German</option>\n<option value=\"fr\">French</option>\n</select></form>",
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",

--- a/tests/forms-empty-label-found.html
+++ b/tests/forms-empty-label-found.html
@@ -10,8 +10,8 @@
 <body>
   <h1>Empty label found</h1>
   <main>
-    <label for="empty"></label>
-<input id="empty" type="text" value="" />
+    <form><label for="empty"></label>
+<input id="empty" type="text" value="" /></form>
   </main>
 </body>
 </html>

--- a/tests/forms-empty-legend.html
+++ b/tests/forms-empty-legend.html
@@ -10,9 +10,9 @@
 <body>
   <h1>Empty legend</h1>
   <main>
-    <fieldset>
+    <form><fieldset>
 <legend></legend>
-</fieldset>
+</fieldset></form>
   </main>
 </body>
 </html>

--- a/tests/forms-error-messages-no-suggestion-for-corrections-given-e.g.-required-format.html
+++ b/tests/forms-error-messages-no-suggestion-for-corrections-given-e.g.-required-format.html
@@ -10,11 +10,11 @@
 <body>
   <h1>Error messages - no suggestion for corrections given, e.g. required format</h1>
   <main>
-    <label class="required-format-not-given">
+    <form><label class="required-format-not-given">
             Phone number
             <span class="error-message">is not valid</span>
 <input class="has-errors" pattern="7[0-9]{9}" required="" type="tel"/>
-</label>
+</label></form>
   </main>
 </body>
 </html>

--- a/tests/forms-field-hint-not-associated-with-input.html
+++ b/tests/forms-field-hint-not-associated-with-input.html
@@ -10,11 +10,11 @@
 <body>
   <h1>Field hint not associated with input</h1>
   <main>
-    <label class="form-label" for="ni-number">
+    <form><label class="form-label" for="ni-number">
             National Insurance number
         </label>
 <p class="form-hint">It'll be on your last payslip. For example, JH 21 90 0A.</p>
-<input class="form-control" id="ni-number" type="text" />
+<input class="form-control" id="ni-number" type="text" /></form>
   </main>
 </body>
 </html>

--- a/tests/forms-fieldset-without-a-legend.html
+++ b/tests/forms-fieldset-without-a-legend.html
@@ -10,9 +10,9 @@
 <body>
   <h1>Fieldset without a legend</h1>
   <main>
-    <fieldset>
+    <form><fieldset>
             I am a fieldset without a legend
-        </fieldset>
+        </fieldset></form>
   </main>
 </body>
 </html>

--- a/tests/forms-form-control-that-changes-context-without-warning.html
+++ b/tests/forms-form-control-that-changes-context-without-warning.html
@@ -10,13 +10,13 @@
 <body>
   <h1>Form control that changes context without warning</h1>
   <main>
-    <label for="language-selector">Select your language</label>
+    <form><label for="language-selector">Select your language</label>
 <select class="language-selector" id="language-selector">
 <option value="">Change your language</option>
 <option value="en">English</option>
 <option value="de">German</option>
 <option value="fr">French</option>
-</select>
+</select></form>
   </main>
 </body>
 </html>

--- a/tests/forms-form-element-has-no-label.html
+++ b/tests/forms-form-element-has-no-label.html
@@ -10,7 +10,7 @@
 <body>
   <h1>Form element has no label</h1>
   <main>
-    <input type="text" />
+    <form><input type="text" /></form>
   </main>
 </body>
 </html>

--- a/tests/forms-group-of-check-boxes-not-enclosed-in-a-fieldset.html
+++ b/tests/forms-group-of-check-boxes-not-enclosed-in-a-fieldset.html
@@ -10,7 +10,7 @@
 <body>
   <h1>Group of check boxes not enclosed in a fieldset</h1>
   <main>
-    <h4>Which types of waste do you transport regularly?</h4>
+    <form><h4>Which types of waste do you transport regularly?</h4>
 <label class="block-label" for="waste-type-1">
 <input id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal" />
             Waste from animal carcasses
@@ -22,7 +22,7 @@
 <label class="block-label" for="waste-type-3">
 <input id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm-agricultural" />
             Farm or agricultural waste
-        </label>
+        </label></form>
   </main>
 </body>
 </html>

--- a/tests/forms-group-of-radio-buttons-not-enclosed-in-a-fieldset.html
+++ b/tests/forms-group-of-radio-buttons-not-enclosed-in-a-fieldset.html
@@ -10,7 +10,7 @@
 <body>
   <h1>Group of radio buttons not enclosed in a fieldset</h1>
   <main>
-    <h4>Do you already have a personal user account?</h4>
+    <form><h4>Do you already have a personal user account?</h4>
 <label class="block-label" for="radio-inline-1">
 <input id="radio-inline-1" name="radio-inline-group" type="radio" value="Yes" />
             Yes
@@ -18,7 +18,7 @@
 <label class="block-label" for="radio-inline-2">
 <input id="radio-inline-2" name="radio-inline-group" type="radio" value="No" />
             No
-        </label>
+        </label></form>
   </main>
 </body>
 </html>

--- a/tests/forms-label-element-with-for-attribute-but-not-matching-id=-attribute-of-form-control.html
+++ b/tests/forms-label-element-with-for-attribute-but-not-matching-id=-attribute-of-form-control.html
@@ -10,11 +10,11 @@
 <body>
   <h1>Label element with for= attribute but not matching id= attribute of form control</h1>
   <main>
-    <fieldset>
+    <form><fieldset>
 <legend>Non-matching for attribute</legend>
 <label id="not-matching-anything">form</label>
 <input id="label-for-not-matching" type="checkbox" value="yes"/>
-</fieldset>
+</fieldset></form>
   </main>
 </body>
 </html>

--- a/tests/forms-labels-missing-when-they-would-look-clumsy-for-some-form-controls.html
+++ b/tests/forms-labels-missing-when-they-would-look-clumsy-for-some-form-controls.html
@@ -10,12 +10,12 @@
 <body>
   <h1>Labels missing when they would look clumsy for some form controls</h1>
   <main>
-    <label for="missing-labels-day">Your child's date of birth</label>
+    <form><label for="missing-labels-day">Your child's date of birth</label>
 <p>
 <input id="missing-labels-day" type="text"/>
 <input id="missing-labels-month" type="text"/>
 <input id="missing-labels-year" type="text"/>
-</p>
+</p></form>
   </main>
 </body>
 </html>

--- a/tests/forms-left-aligned-form-labels-with-too-much-white-space.html
+++ b/tests/forms-left-aligned-form-labels-with-too-much-white-space.html
@@ -10,10 +10,10 @@
 <body>
   <h1>Left aligned form labels with too much white space</h1>
   <main>
-    <p class="too-much-whitespace">
+    <form><p class="too-much-whitespace">
 <label for="input-too-far-away">Country</label>
 <input id="input-too-far-away" type="text"/>
-</p>
+</p></form>
   </main>
 </body>
 </html>

--- a/tests/forms-missing-labels-in-checkboxes.html
+++ b/tests/forms-missing-labels-in-checkboxes.html
@@ -10,7 +10,7 @@
 <body>
   <h1>Missing labels in checkboxes</h1>
   <main>
-    <fieldset>
+    <form><fieldset>
 <legend>What is your nationality?</legend>
 <label>British (including English, Scottish, Welsh and Northern Irish)</label>
 <input id="nationality_british" name="nationality.british" type="checkbox" value="true" />
@@ -18,7 +18,7 @@
 <input id="nationality_irish" name="nationality.irish" type="checkbox" value="true" />
 <label>Citizen of a different country</label>
 <input id="nationality_hasOtherCountry" name="nationality.hasOtherCountry" type="checkbox" value="true" />
-</fieldset>
+</fieldset></form>
   </main>
 </body>
 </html>

--- a/tests/forms-non-unique-field-label-found.html
+++ b/tests/forms-non-unique-field-label-found.html
@@ -10,10 +10,10 @@
 <body>
   <h1>Non-unique field label found</h1>
   <main>
-    <label for="x_3">Name
+    <form><label for="x_3">Name
             <input id="x_3" name="x_3" type="text" /></label><br />
 <label for="x_4">Name
-            <input id="x_4" name="x_4" type="text" /></label>
+            <input id="x_4" name="x_4" type="text" /></label></form>
   </main>
 </body>
 </html>

--- a/tests/forms-placeholder-no-label.html
+++ b/tests/forms-placeholder-no-label.html
@@ -10,8 +10,8 @@
 <body>
   <h1>Placeholder no label</h1>
   <main>
-    <input id="search-main" name="q" placeholder="Search" type="search" />
-<input class="submit" type="submit" value="Search" />
+    <form><input id="search-main" name="q" placeholder="Search" type="search" />
+<input class="submit" type="submit" value="Search" /></form>
   </main>
 </body>
 </html>

--- a/tests/forms-two-unique-labels-but-identical-for=-attributes.html
+++ b/tests/forms-two-unique-labels-but-identical-for=-attributes.html
@@ -10,7 +10,7 @@
 <body>
   <h1>Two unique labels, but identical for= attributes</h1>
   <main>
-    <label for="two-labels-day">Date of issue</label>
+    <form><label for="two-labels-day">Date of issue</label>
 <p>
 <label for="two-labels-day">Day</label>
 <input id="two-labels-day" type="text"/>
@@ -18,7 +18,7 @@
 <input id="two-labels-month" type="text"/>
 <label for="two-labels-year">Year</label>
 <input id="two-labels-year" type="text"/>
-</p>
+</p></form>
   </main>
 </body>
 </html>


### PR DESCRIPTION
Some tools don't test realiably when the form tag is missing from around form fields, e.g. Asqatasun.
This adds a form tag around all form examples.