### PR TITLE
Update feature comparison table

### DIFF
--- a/build/generate.js
+++ b/build/generate.js
@@ -130,7 +130,7 @@ function generateFiles(){
     tests: tests,
     getFilename: getFilename,
     analysis: analysisResults,
-    tCopy: toolNamesCopy,
+    tools: tools,
     changes: changes
   });
   fs.writeFileSync(paths.out('index.html'), indexout, 'utf8');

--- a/build/generate.js
+++ b/build/generate.js
@@ -49,7 +49,7 @@ var tools = {
   },
   "axe": {
     name: toolNamesCopy["axe"],
-    url: "http://www.deque.com/products/axe/"
+    url: "https://www.axe-core.org/"
   },
   "asqatasun": {
     name: toolNamesCopy["asqatasun"],

--- a/build/templates/index.html
+++ b/build/templates/index.html
@@ -158,7 +158,7 @@
             <th scope="col">In-browser</th>
             <th scope="col">Internal use</th>
             <th scope="col">Mobile</th>
-            <th scope="col">Scriptable</th>
+            <th scope="col">Script&shy;able</th>
             <th scope="col">HTTP Auth</th>
             <th scope="col">Guidance</th>
           </tr>
@@ -181,8 +181,8 @@
           </tr>
           <tr>
             <th scope="row">Tenon</th>
-            <td>Free trial</td>
-            <td>$47/month</td>
+            <td>Free&nbsp;trial,<br />from $47 per&nbsp;month</td>
+            <td>From $47 per&nbsp;month</td>
             <td>No</td>
             <td>Yes</td>
             <td>Yes</td>
@@ -197,9 +197,9 @@
           <tr>
             <th scope="row">WAVE</th>
             <td>Free</td>
-            <td>min $10</td>
+            <td>Free&nbsp;trial,<br />minimum $10 for 250 API calls</td>
             <td>No</td>
-            <td>?</td>
+            <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
@@ -210,11 +210,11 @@
             <td>OK</td>
           </tr>
           <tr>
-            <th scope="row">HTML_CodeSniffer</th>
+            <th scope="row">HTML_&shy;Code&shy;Sniffer</th>
             <td>Free</td>
             <td>Free</td>
             <td>Yes</td>
-            <td>No</td>
+            <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
@@ -240,7 +240,7 @@
             <td>Good</td>
           </tr>
           <tr>
-            <th scope="row">Asqatasun</th>
+            <th scope="row">Asqa&shy;tasun</th>
             <td>Free</td>
             <td>Free</td>
             <td>Yes</td>
@@ -255,18 +255,18 @@
             <td>Good</td>
           </tr>
           <tr>
-            <th scope="row">Sortsite</th>
-            <td>Free</td>
-            <td>&pound;89.10 / &pound;494.10</td>
+            <th scope="row">Sort&shy;Site</th>
+            <td>Free&nbsp;trial,<br />from £24.50 per&nbsp;month or £69.30 once</td>
+            <td>From £384.30 once</td>
             <td>No</td>
             <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
             <td>No</td>
+            <td>Yes</td>
             <td>No</td>
             <td>No</td>
-            <td>No</td>
-            <td>No</td>
+            <td>Yes</td>
             <td>Good</td>
           </tr>
           <tr>
@@ -289,7 +289,7 @@
             <td>Free</td>
             <td>N/A</td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td>No</td>
             <td>No</td>
             <td>No</td>
             <td>No</td>
@@ -315,7 +315,7 @@
             <td>No</td>
           </tr>
           <tr>
-            <th scope="row">Siteimprove</th>
+            <th scope="row">Site&shy;improve</th>
             <td>Free</td>
             <td>N/A</td>
             <td>No</td>

--- a/build/templates/index.html
+++ b/build/templates/index.html
@@ -56,7 +56,7 @@
         <tbody>
           {% for score in analysis.scoreboard.by_error_warning -%}
             <tr>
-              <th>{{ tCopy[score.name] | safe }}</th>
+              <th><a href="{{ tools[score.name].url }}">{{ tools[score.name].name | safe }}</a></th>
               <td>{{ score.error_warning }}%</td>
               <td>{{ score.error_warning_manual }}%</td>
             </tr>

--- a/build/templates/results.html
+++ b/build/templates/results.html
@@ -112,17 +112,17 @@
         <th scope="col"><a href="http://tenon.io">Tenon</a></th>
         <th scope="col"><a href="http://wave.webaim.org">WAVE</a></th>
         <th scope="col"><a href="http://squizlabs.github.io/HTML_CodeSniffer/">HTML_&shy;Code&shy;Sniffer</a></th>
-        <th scope="col"><a href="https://github.com/dequelabs/axe-core">aXe</a></th>
+        <th scope="col"><a href="https://www.axe-core.org/">aXe</a></th>
         <th scope="col"><a href="http://asqatasun.org/">Asqa&shy;tasun</a></th>
         <th scope="col"><a href="http://www.powermapper.com/products/sortsite/">Sort&shy;Site</a></th>
         <th scope="col">
-          <a href="http://checkers.eiii.eu/?url=https%3A%2F%2Falphagov.github.io%2Faccessibility-tool-audit%2Ftest-cases.html">
+          <a href="http://checkers.eiii.eu/">
             <abbr title="European Internet Inclusion Initiative">EIII</abbr>
           </a>
         </th>
         <th scope="col"><a href="http://achecker.ca/">AChecker</a></th>
         <th scope="col">
-          <a href="https://validator.nu/?doc=https%3A%2F%2Falphagov.github.io%2Faccessibility-tool-audit%2Ftest-cases.html">
+          <a href="https://validator.w3.org/nu/">
             Nu Html Checker
           </a>
         </th>

--- a/index.html
+++ b/index.html
@@ -72,51 +72,51 @@
         </thead>
         <tbody>
           <tr>
-              <th>Tenon</th>
+              <th><a href="https://tenon.io/">Tenon</a></th>
               <td>37%</td>
               <td>37%</td>
             </tr><tr>
-              <th>AChecker</th>
+              <th><a href="http://achecker.ca/">AChecker</a></th>
               <td>30%</td>
               <td>32%</td>
             </tr><tr>
-              <th>Siteimprove</th>
+              <th><a href="https://siteimprove.com/">Siteimprove</a></th>
               <td>29%</td>
               <td>36%</td>
             </tr><tr>
-              <th>aXe</th>
+              <th><a href="https://www.axe-core.org/">aXe</a></th>
               <td>29%</td>
               <td>30%</td>
             </tr><tr>
-              <th><abbr title="Functional Accessibility Evaluator">FAE</abbr></th>
+              <th><a href="https://fae.disability.illinois.edu/"><abbr title="Functional Accessibility Evaluator">FAE</abbr></a></th>
               <td>28%</td>
               <td>51%</td>
             </tr><tr>
-              <th>Asqatasun</th>
+              <th><a href="http://asqatasun.org/">Asqatasun</a></th>
               <td>28%</td>
               <td>43%</td>
             </tr><tr>
-              <th>WAVE</th>
+              <th><a href="http://wave.webaim.org/extension/">WAVE</a></th>
               <td>27%</td>
               <td>29%</td>
             </tr><tr>
-              <th>SortSite</th>
+              <th><a href="https://www.powermapper.com/products/sortsite/">SortSite</a></th>
               <td>27%</td>
               <td>27%</td>
             </tr><tr>
-              <th>HTML_CodeSniffer</th>
+              <th><a href="https://squizlabs.github.io/HTML_CodeSniffer/">HTML_CodeSniffer</a></th>
               <td>23%</td>
               <td>34%</td>
             </tr><tr>
-              <th>Google ADT</th>
+              <th><a href="https://github.com/GoogleChrome/accessibility-developer-tools">Google ADT</a></th>
               <td>17%</td>
               <td>17%</td>
             </tr><tr>
-              <th><abbr title="European Internet Inclusion Initiative">EIII</abbr></th>
+              <th><a href="http://checkers.eiii.eu/"><abbr title="European Internet Inclusion Initiative">EIII</abbr></a></th>
               <td>16%</td>
               <td>16%</td>
             </tr><tr>
-              <th>Nu Html Checker</th>
+              <th><a href="https://validator.w3.org/nu/">Nu Html Checker</a></th>
               <td>13%</td>
               <td>16%</td>
             </tr>
@@ -217,7 +217,7 @@
             <th scope="col">In-browser</th>
             <th scope="col">Internal use</th>
             <th scope="col">Mobile</th>
-            <th scope="col">Scriptable</th>
+            <th scope="col">Script&shy;able</th>
             <th scope="col">HTTP Auth</th>
             <th scope="col">Guidance</th>
           </tr>
@@ -240,8 +240,8 @@
           </tr>
           <tr>
             <th scope="row">Tenon</th>
-            <td>Free trial</td>
-            <td>$47/month</td>
+            <td>Free&nbsp;trial,<br />from $47 per&nbsp;month</td>
+            <td>From $47 per&nbsp;month</td>
             <td>No</td>
             <td>Yes</td>
             <td>Yes</td>
@@ -256,9 +256,9 @@
           <tr>
             <th scope="row">WAVE</th>
             <td>Free</td>
-            <td>min $10</td>
+            <td>Free&nbsp;trial,<br />minimum $10 for 250 API calls</td>
             <td>No</td>
-            <td>?</td>
+            <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
@@ -269,11 +269,11 @@
             <td>OK</td>
           </tr>
           <tr>
-            <th scope="row">HTML_CodeSniffer</th>
+            <th scope="row">HTML_&shy;Code&shy;Sniffer</th>
             <td>Free</td>
             <td>Free</td>
             <td>Yes</td>
-            <td>No</td>
+            <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
@@ -299,7 +299,7 @@
             <td>Good</td>
           </tr>
           <tr>
-            <th scope="row">Asqatasun</th>
+            <th scope="row">Asqa&shy;tasun</th>
             <td>Free</td>
             <td>Free</td>
             <td>Yes</td>
@@ -314,18 +314,18 @@
             <td>Good</td>
           </tr>
           <tr>
-            <th scope="row">Sortsite</th>
-            <td>Free</td>
-            <td>&pound;89.10 / &pound;494.10</td>
+            <th scope="row">Sort&shy;Site</th>
+            <td>Free&nbsp;trial,<br />from £24.50 per&nbsp;month or £69.30 once</td>
+            <td>From £384.30 once</td>
             <td>No</td>
             <td>Yes</td>
             <td>Yes</td>
             <td>Yes</td>
             <td>No</td>
+            <td>Yes</td>
             <td>No</td>
             <td>No</td>
-            <td>No</td>
-            <td>No</td>
+            <td>Yes</td>
             <td>Good</td>
           </tr>
           <tr>
@@ -348,7 +348,7 @@
             <td>Free</td>
             <td>N/A</td>
             <td>Yes</td>
-            <td>Yes</td>
+            <td>No</td>
             <td>No</td>
             <td>No</td>
             <td>No</td>
@@ -374,7 +374,7 @@
             <td>No</td>
           </tr>
           <tr>
-            <th scope="row">Siteimprove</th>
+            <th scope="row">Site&shy;improve</th>
             <td>Free</td>
             <td>N/A</td>
             <td>No</td>

--- a/results.html
+++ b/results.html
@@ -125,17 +125,17 @@
         <th scope="col"><a href="http://tenon.io">Tenon</a></th>
         <th scope="col"><a href="http://wave.webaim.org">WAVE</a></th>
         <th scope="col"><a href="http://squizlabs.github.io/HTML_CodeSniffer/">HTML_&shy;Code&shy;Sniffer</a></th>
-        <th scope="col"><a href="https://github.com/dequelabs/axe-core">aXe</a></th>
+        <th scope="col"><a href="https://www.axe-core.org/">aXe</a></th>
         <th scope="col"><a href="http://asqatasun.org/">Asqa&shy;tasun</a></th>
         <th scope="col"><a href="http://www.powermapper.com/products/sortsite/">Sort&shy;Site</a></th>
         <th scope="col">
-          <a href="http://checkers.eiii.eu/?url=https%3A%2F%2Falphagov.github.io%2Faccessibility-tool-audit%2Ftest-cases.html">
+          <a href="http://checkers.eiii.eu/">
             <abbr title="European Internet Inclusion Initiative">EIII</abbr>
           </a>
         </th>
         <th scope="col"><a href="http://achecker.ca/">AChecker</a></th>
         <th scope="col">
-          <a href="https://validator.nu/?doc=https%3A%2F%2Falphagov.github.io%2Faccessibility-tool-audit%2Ftest-cases.html">
+          <a href="https://validator.w3.org/nu/">
             Nu Html Checker
           </a>
         </th>


### PR DESCRIPTION
Some of the facts in the feature comparison table were outdated. This updates them:

* WAVE and HTML_CodeSniffer are still active while AChecker is not
  (last updates to WAVE: 28 Nov 2017, HTMLCS: 12 Sep 2017
  and AChecker: 6 Sep 2013)
* SortSite can be used internally and behind authentication
  when using the downloadable software
* SortSite is not completely free but offers a free trial
* Add costs to all free trials
* WAVE CI has a free trial, clarify what you get for $10
* Update and re-phrase CI costs so they say "from (the lowest cost)"
  to reflect that tools usually have different types of pricing

I also added links to tools in the result table on the start page and adjusted the following URLs to the tools:
* Used axe-core.org for aXe as it is user-friendlier than the GitHub page
* Removed URL parameters from EIII as it is not working
* Also removed parameters from Nu as it would be the only one left
* Changed Nu to use w3.org URL (which is the same backend)
