### PR TITLE
Improve overview semantics

### DIFF
--- a/build/templates/index.html
+++ b/build/templates/index.html
@@ -347,11 +347,14 @@
         </tbody>
       </table>
 
-      <h2 class="heading-medium"><a href="results.html">Read detailed test results</a></h2>
 
-      <h2 class="heading-medium"><a href="test-cases.html">See everything we tested</a></h2>
+      <h2>Read more</h2>
 
-      <h2 class="heading-medium"><a href="https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/">Read our blog post on what we found</a></h2>
+      <p class="heading-medium"><a href="results.html">Read detailed test results</a></p>
+
+      <p class="heading-medium"><a href="test-cases.html">See everything we tested</a></p>
+
+      <p class="heading-medium"><a href="https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/">Read our blog post on what we found</a></p>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -406,11 +406,14 @@
         </tbody>
       </table>
 
-      <h2 class="heading-medium"><a href="results.html">Read detailed test results</a></h2>
 
-      <h2 class="heading-medium"><a href="test-cases.html">See everything we tested</a></h2>
+      <h2>Read more</h2>
 
-      <h2 class="heading-medium"><a href="https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/">Read our blog post on what we found</a></h2>
+      <p class="heading-medium"><a href="results.html">Read detailed test results</a></p>
+
+      <p class="heading-medium"><a href="test-cases.html">See everything we tested</a></p>
+
+      <p class="heading-medium"><a href="https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/">Read our blog post on what we found</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
The overview page has a couple of links at the bottom within an h3 each. That is neither very semantic nor accessible.
This changes that to a paragraph instead and gives the set a heading.