### PR TITLE
Add more documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# How to contribute
+
+We welcome issues / pull requests for updated or new test cases or tool results.
+
+Make changes to the build files first (mainly 'tests.json' but also anything under the 'build' folder) and add the static files that get created or updated via the `gulp` command in a separate commit last.
+You also might want to update 'changelog.json' but it likely needs changing again to update the date to be the date when the Pull Request gets merged.
+It's also fine if you don't add the changes to the the changelog and static files at all, we can do that before we merge.
+
+When using a tool, use all the most inquisitive options. For example, if you have the choice between AA and AAA, choose AAA. If you have the choice to add options which don't seem to be related to accessibility (SEO, for example), test those as well.
+
+You should check each test page on its own and not the one big page including (nearly) all tests. Then check if the one particular issue we were expecting to find on that page is found or not. To look for just one issue makes it easier to find.
+Don't test any of the test pages which contain only a link to an "example page" but test that example page instead to which the links points. Those are the pages that are not included within the one big page but need to be on pages of their own.
+
+When you add or change the test results, you need to note them as the key in the `resultsCopy` variable in 'build/generate.js'. That will be automatically translated to what you see on the results page (for example, "error" translates to "Issue found" and "notfound" translates to "Not found").
+
+
+## Update test results
+
+When you have found a result you disagree with or you re-test a tool because it was updated, you should add your changes to the `results` of each relevant test entry within 'tests.json'.
+
+
+## Change code examples
+
+When you can think of an improvement to an existing test case, you should update the `example` of each relevant test entry within 'tests.json'. Then you should re-test that example with **every single tool** and update their results accordingly.
+
+
+## Add new code examples
+
+If you like to add a new test case, create a new entry within 'tests.json' as the last entry under its most relevant section ("Content", "Page Layout", etc). Then test **every single tool** with that example and update their results accordingly.
+
+Because some tools don't work with local files, you can add the example to a [JS Bin](http://jsbin.com/) or similar and test that instead. That also helps developing that example as making the changes within 'tests.json' is cumbersome.
+
+Try to make the example as isolated as possible. Although complex examples make more realistic test cases, testing for one specific issue is easier and more reliable to test for.
+
+
+## Add new tool
+
+We currently only accept tools which are either free or free to try and which are not based on any tool we have already covered. When it's a paid for tool, it should have a pricing option which is affordable by a small team. It must have a web presence with all important information.
+It's best to first open a [GitHub issue](https://github.com/alphagov/accessibility-tool-audit/issues/new) and ask if we would accept the tool. That will reduce potentially wasted efforts.
+
+When you add a new tool, you will need to check every single of the test cases.
+
+To add a new tool you would need to add it to these files:
+
+* 'build/analysis.js': add the name as a slug to `toolNames`
+* 'build/generate.js': add that slug and its proper full name to `toolNamesCopy`
+* 'build/generate.js': add the name and URL to `tools`
+* 'build/templates/results.html': add a new `th` to the end of the table head
+* 'build/templates/results.html': add a new `td` to the end of the inner loop within the table body by referencing the slug within the variables
+* 'build/templates/index.html': research the necessary features and add a new table row at the end of the feature comparison table and fill it with the relevant facts about the tool
+
+Then add results of this tool by adding a new `results` line to every single entry in 'tests.json'.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ You also might want to update 'changelog.json' but it likely needs changing agai
 It's also fine if you don't add the changes to the the changelog and static files at all, we can do that before we merge.
 
 When using a tool, use all the most inquisitive options. For example, if you have the choice between AA and AAA, choose AAA. If you have the choice to add options which don't seem to be related to accessibility (SEO, for example), test those as well.
+Check the list of [options we used](tools-info.md#options-and-settings).
 
 You should check each test page on its own and not the one big page including (nearly) all tests. Then check if the one particular issue we were expecting to find on that page is found or not. To look for just one issue makes it easier to find.
 Don't test any of the test pages which contain only a link to an "example page" but test that example page instead to which the links points. Those are the pages that are not included within the one big page but need to be on pages of their own.
@@ -17,6 +18,7 @@ When you add or change the test results, you need to note them as the key in the
 ## Update test results
 
 When you have found a result you disagree with or you re-test a tool because it was updated, you should add your changes to the `results` of each relevant test entry within 'tests.json'.
+Check the [tools' changelogs](tools-info.md#changelogs) to know when a tool has been updated.
 
 
 ## Change code examples
@@ -48,5 +50,6 @@ To add a new tool you would need to add it to these files:
 * 'build/templates/results.html': add a new `th` to the end of the table head
 * 'build/templates/results.html': add a new `td` to the end of the inner loop within the table body by referencing the slug within the variables
 * 'build/templates/index.html': research the necessary features and add a new table row at the end of the feature comparison table and fill it with the relevant facts about the tool
+* 'tools-info.md': add info about settings and where to find the tool's changelog to the end of each list
 
 Then add results of this tool by adding a new `results` line to every single entry in 'tests.json'.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ The test cases are a collection of the wide variety of potential accessibility i
 
 ## Contributing / updating results
 
-We welcome issues / pull requests for updated test cases or tool results. All relevant content can be found in `tests.json`. (All the HTML files are automatically created from that one file.)
+We welcome issues / pull requests for updated or new test cases or tool results. All relevant content can be found in `tests.json`. (All the HTML files are automatically created from that one file.)
+Read more on [how to contribute](CONTRIBUTING.md).
 
 ## Installing
 
 Make sure you have the gulp command installed beforehand.
 
-``` 
+```
 npm install -g gulp
 ```
 

--- a/tools-info.md
+++ b/tools-info.md
@@ -1,0 +1,39 @@
+# More info on tools
+
+When updating results for a specific tool it helps to know if or when a tool has been updated last and what to look out for when testing it.
+
+
+## Options and settings
+
+Try to use all the most inquisitive options. This is a list of options per tool which we are aware of and used:
+
+* Google Accessibility Developer Tools: default
+* Tenon: default
+* WAVE: default
+* HTML CodeSniffer: choose WCAG2AAA standards, select errors and warnings and notices
+* aXe: choose all tags (wcag2a,wcag2aa,section508,best-practice,experimental) or use the aXe-Coconut extension
+* Asqatasun: "Audit Pages" not "Audit Full-site" (some tests won't run in the full-site audit), choose level AAA (RGAA 3.0),
+* SortSite: WCAG 2.0 AAA, Section 508 Refresh (2017), Check screen reader support, Universal reading age, check Compatibility (with default settings), Search (with all options), Standards (with all options), Usability
+* EIII: (none)
+* AChecker: Enable HTML Validator, Enable CSS Validator, choose WCAG 2.0 (Level AAA)
+* Nu Html Checker: add image report
+* Siteimprove: choose AAA conformance, select error and warning and review severity
+* FAE: default (except it's recommended to uncheck 'include pass and n/a results' for better readability)
+
+
+## Changelogs
+
+To know if a tool was updated since we last tested it, check these changelogs:
+
+* [Google Accessibility Developer Tools changelog](https://github.com/GoogleChrome/accessibility-developer-tools/releases)
+* [Tenon changelog](https://tenon.io/documentation/changelog.php)
+* WAVE doesn't have a changelog, but they occasionally [blog about WAVE updates](https://webaim.org/blog/?s=wave)
+* [HTML CodeSniffer changelog](https://github.com/squizlabs/HTML_CodeSniffer/releases)
+* [aXe changelog](https://github.com/dequelabs/axe-core/releases)
+* [Asqatasun changelog](https://github.com/Asqatasun/Asqatasun/releases)
+* [SortSite changelog](https://www.powermapper.com/products/sortsite/versions/) is only for the Desktop version, but presumably the history of the online version must be very similar
+* [EIII changelog](https://gitlab.tingtun.no/eiii_source/checker-suite/commits/master)
+* [AChecker changelog](https://github.com/inclusive-design/AChecker/releases)
+* [Nu Html Checker changelog](https://github.com/validator/validator/releases)
+* Siteimprove doesn't have a changelog, but their [Siteimprove Chrome extension](https://chrome.google.com/webstore/detail/siteimprove-accessibility/efcfolpjihicnikpmhnmphjhhpiclljc) lists a version number and a date when it was last updated
+* [FAE changelog](https://fae.disability.illinois.edu/abouts/versions/)


### PR DESCRIPTION
We don't have any documentation which tells people how to make any changes.
This adds information in a CONTRIBUTING file on how to
* update existing test results
* change existing code examples
* add new code examples
* add a new tool and the requirements for including it

and what to generally look out for when testing a tool.

And it adds another file which lists changelogs and options to use for each tool.