### PR TITLE
Add new tool: ASLint

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -95,15 +95,23 @@
       "warning": 4,
       "manual": 31,
       "identified": 0
+    },
+    "aslint": {
+      "notfound": 89,
+      "error": 33,
+      "error_paid": 0,
+      "warning": 7,
+      "manual": 10,
+      "identified": 3
     }
   },
   "totals": {
     "total": 142,
-    "detectable": 119,
-    "undetectable": 23
+    "detectable": 122,
+    "undetectable": 20
   },
   "percentages": {
-    "detectable": 84,
+    "detectable": 86,
     "tools": {
       "google": {
         "detectable": {
@@ -117,8 +125,8 @@
       },
       "tenon": {
         "detectable": {
-          "error_warning": 44,
-          "error_warning_manual": 44
+          "error_warning": 43,
+          "error_warning_manual": 43
         },
         "total": {
           "error_warning": 37,
@@ -127,8 +135,8 @@
       },
       "wave": {
         "detectable": {
-          "error_warning": 33,
-          "error_warning_manual": 35
+          "error_warning": 32,
+          "error_warning_manual": 34
         },
         "total": {
           "error_warning": 27,
@@ -137,8 +145,8 @@
       },
       "codesniffer": {
         "detectable": {
-          "error_warning": 27,
-          "error_warning_manual": 40
+          "error_warning": 26,
+          "error_warning_manual": 39
         },
         "total": {
           "error_warning": 23,
@@ -148,7 +156,7 @@
       "axe": {
         "detectable": {
           "error_warning": 34,
-          "error_warning_manual": 36
+          "error_warning_manual": 35
         },
         "total": {
           "error_warning": 29,
@@ -158,7 +166,7 @@
       "asqatasun": {
         "detectable": {
           "error_warning": 29,
-          "error_warning_manual": 56
+          "error_warning_manual": 55
         },
         "total": {
           "error_warning": 25,
@@ -167,8 +175,8 @@
       },
       "sortsite": {
         "detectable": {
-          "error_warning": 48,
-          "error_warning_manual": 48
+          "error_warning": 47,
+          "error_warning_manual": 47
         },
         "total": {
           "error_warning": 40,
@@ -187,8 +195,8 @@
       },
       "achecker": {
         "detectable": {
-          "error_warning": 37,
-          "error_warning_manual": 41
+          "error_warning": 36,
+          "error_warning_manual": 40
         },
         "total": {
           "error_warning": 31,
@@ -208,7 +216,7 @@
       "siteimprove": {
         "detectable": {
           "error_warning": 34,
-          "error_warning_manual": 43
+          "error_warning_manual": 42
         },
         "total": {
           "error_warning": 29,
@@ -217,12 +225,22 @@
       },
       "fae": {
         "detectable": {
-          "error_warning": 34,
-          "error_warning_manual": 60
+          "error_warning": 33,
+          "error_warning_manual": 58
         },
         "total": {
           "error_warning": 28,
           "error_warning_manual": 50
+        }
+      },
+      "aslint": {
+        "detectable": {
+          "error_warning": 33,
+          "error_warning_manual": 41
+        },
+        "total": {
+          "error_warning": 28,
+          "error_warning_manual": 35
         }
       }
     }
@@ -261,42 +279,48 @@
       },
       {
         "position": 6,
+        "name": "aslint",
+        "error_warning": 28,
+        "error_warning_manual": 35
+      },
+      {
+        "position": 7,
         "name": "fae",
         "error_warning": 28,
         "error_warning_manual": 50
       },
       {
-        "position": 7,
+        "position": 8,
         "name": "wave",
         "error_warning": 27,
         "error_warning_manual": 30
       },
       {
-        "position": 8,
+        "position": 9,
         "name": "asqatasun",
         "error_warning": 25,
         "error_warning_manual": 47
       },
       {
-        "position": 9,
+        "position": 10,
         "name": "codesniffer",
         "error_warning": 23,
         "error_warning_manual": 34
       },
       {
-        "position": 10,
+        "position": 11,
         "name": "eiii",
         "error_warning": 17,
         "error_warning_manual": 17
       },
       {
-        "position": 11,
+        "position": 12,
         "name": "google",
         "error_warning": 17,
         "error_warning_manual": 17
       },
       {
-        "position": 12,
+        "position": 13,
         "name": "nu",
         "error_warning": 13,
         "error_warning_manual": 16
@@ -335,21 +359,21 @@
       },
       {
         "position": 6,
+        "name": "aslint",
+        "error_warning": 28,
+        "error_warning_manual": 35
+      },
+      {
+        "position": 7,
         "name": "achecker",
         "error_warning": 31,
         "error_warning_manual": 35
       },
       {
-        "position": 7,
+        "position": 8,
         "name": "codesniffer",
         "error_warning": 23,
         "error_warning_manual": 34
-      },
-      {
-        "position": 8,
-        "name": "wave",
-        "error_warning": 27,
-        "error_warning_manual": 30
       },
       {
         "position": 9,
@@ -359,18 +383,24 @@
       },
       {
         "position": 10,
+        "name": "wave",
+        "error_warning": 27,
+        "error_warning_manual": 30
+      },
+      {
+        "position": 11,
         "name": "eiii",
         "error_warning": 17,
         "error_warning_manual": 17
       },
       {
-        "position": 11,
+        "position": 12,
         "name": "google",
         "error_warning": 17,
         "error_warning_manual": 17
       },
       {
-        "position": 12,
+        "position": 13,
         "name": "nu",
         "error_warning": 13,
         "error_warning_manual": 16

--- a/build/analysis.js
+++ b/build/analysis.js
@@ -34,7 +34,8 @@ var toolNames = [
   'achecker',
   'nu',
   'siteimprove',
-  'fae'
+  'fae',
+  'aslint'
 ];
 
 var analysis = {};

--- a/build/generate.js
+++ b/build/generate.js
@@ -33,7 +33,8 @@ var toolNamesCopy = {
   "eiii": '<abbr title="European Internet Inclusion Initiative">EIII</abbr>',
   "nu": "Nu Html Checker",
   "siteimprove": "Siteimprove",
-  "fae": '<abbr title="Functional Accessibility Evaluator">FAE</abbr>'
+  "fae": '<abbr title="Functional Accessibility Evaluator">FAE</abbr>',
+  "aslint": "ASLint"
 }
 
 var tools = {
@@ -84,6 +85,10 @@ var tools = {
   "fae": {
     name: toolNamesCopy["fae"],
     url: "https://fae.disability.illinois.edu/"
+  },
+  "aslint": {
+    name: toolNamesCopy["aslint"],
+    url: "https://www.aslint.org/"
   }
 }
 

--- a/build/templates/index.html
+++ b/build/templates/index.html
@@ -344,6 +344,21 @@
             <td>Yes</td>
             <td>OK</td>
           </tr>
+          <tr>
+            <th scope="row">AS&shy;Lint</th>
+            <td>Free</td>
+            <td>Free</td>
+            <td>No</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>?</td>
+            <td>Yes</td>
+            <td>OK</td>
+          </tr>
         </tbody>
       </table>
 

--- a/build/templates/results.html
+++ b/build/templates/results.html
@@ -124,6 +124,7 @@
             <abbr title="Functional Accessibility Evaluator">FAE</abbr>
           </a>
         </th>
+        <th scope="col"><a href="https://www.aslint.org/">AS&shy;Lint</a></th>
       </tr>
     </thead>
     <tbody>
@@ -170,6 +171,9 @@
             </td>
             <td class="{{ testobj.results.fae }}">
               {{ rcopy[testobj.results.fae] | capitalize }}
+            </td>
+            <td class="{{ testobj.results.aslint }}">
+              {{ rcopy[testobj.results.aslint] | capitalize }}
             </td>
           </tr>
         {% endfor %}

--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,11 @@
 {
-  "last_updated": "15 January 2018",
+  "last_updated": "13 February 2018",
   "changelog": [
+    {
+      "date": "13 February 2018",
+      "text": "Added new tool: ASLint",
+      "link": "https://github.com/alphagov/accessibility-tool-audit/pull/34"
+    },
     {
       "date": "13 February 2018",
       "text": "Re-interpreted some results due to removal of less helpful categories",

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       <h1>How do automated accessibility checkers compare?</h1>
 
       <p>
-        We ran an audit to see what issues the different accessibility testing tools pick up. We deliberately introduced 142 accessibility barriers to a page of content, and ran them through 12 automated tools. We also had a look at features like usability and cost.
+        We ran an audit to see what issues the different accessibility testing tools pick up. We deliberately introduced 142 accessibility barriers to a page of content, and ran them through 13 automated tools. We also had a look at features like usability and cost.
       </p>
 
       <p>You can use our audit to help choose the best accessibility testing tool for your service.</p>
@@ -92,6 +92,10 @@
               <td>29%</td>
               <td>30%</td>
             </tr><tr>
+              <th><a href="https://www.aslint.org/">ASLint</a></th>
+              <td>28%</td>
+              <td>35%</td>
+            </tr><tr>
               <th><a href="https://fae.disability.illinois.edu/"><abbr title="Functional Accessibility Evaluator">FAE</abbr></a></th>
               <td>28%</td>
               <td>50%</td>
@@ -123,7 +127,7 @@
         </tbody>
       </table>
 
-      <p><small>Last updated: 15 January 2018</small></p>
+      <p><small>Last updated: 13 February 2018</small></p>
 
       <h3>How do features compare?</h3>
 
@@ -400,6 +404,21 @@
             <td>Yes</td>
             <td>Yes</td>
             <td>No</td>
+            <td>Yes</td>
+            <td>OK</td>
+          </tr>
+          <tr>
+            <th scope="row">AS&shy;Lint</th>
+            <td>Free</td>
+            <td>Free</td>
+            <td>No</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>?</td>
             <td>Yes</td>
             <td>OK</td>
           </tr>

--- a/results.html
+++ b/results.html
@@ -40,7 +40,7 @@
     </p>
 
     <p class="data column-third">
-      <span class="data-item bold-xxlarge">12</span>
+      <span class="data-item bold-xxlarge">13</span>
       <span class="data-item bold-xsmall">tools tested</span>
     </p>
 
@@ -52,7 +52,7 @@
 
   <div class="grid-row">
     <div class="column-two-thirds">
-      <p>We sometimes update specific test results for individual tools. See the <a href="#changelog">changelog</a> for full details. We last made updates on 15 January 2018.</p>
+      <p>We sometimes update specific test results for individual tools. See the <a href="#changelog">changelog</a> for full details. We last made updates on 13 February 2018.</p>
 
       <div class="form-group">
         <details>
@@ -137,6 +137,7 @@
             <abbr title="Functional Accessibility Evaluator">FAE</abbr>
           </a>
         </th>
+        <th scope="col"><a href="https://www.aslint.org/">AS&shy;Lint</a></th>
       </tr>
     </thead>
     <tbody>
@@ -183,6 +184,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -227,6 +231,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -235,6 +242,9 @@
                 Content is not in correct reading order in source code
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -315,6 +325,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -359,6 +372,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
 
@@ -369,6 +385,9 @@
                 Wide page forces users to scroll horizontally
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -451,6 +470,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="manual">
+              User to check
+            </td>
           </tr>
         
           <tr>
@@ -495,6 +517,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -535,6 +560,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -583,6 +611,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -623,6 +654,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -671,6 +705,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
 
@@ -681,6 +718,9 @@
                 Inadequate line height used
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -761,6 +801,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="warning">
+              Warning only
+            </td>
           </tr>
         
           <tr>
@@ -804,6 +847,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="warning">
+              Warning only
             </td>
           </tr>
         
@@ -849,6 +895,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="warning">
+              Warning only
+            </td>
           </tr>
         
           <tr>
@@ -893,6 +942,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -901,6 +953,9 @@
                 Long lines of text
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -981,6 +1036,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -1025,6 +1083,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
 
@@ -1040,6 +1101,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -1115,6 +1179,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -1159,6 +1226,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -1167,6 +1237,9 @@
                 Text language is in the wrong direction
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -1247,6 +1320,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -1291,6 +1367,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -1328,6 +1407,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="error">
+              Issue found
             </td>
             <td class="error">
               Issue found
@@ -1379,6 +1461,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -1404,6 +1489,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -1469,6 +1557,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -1513,6 +1604,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -1521,6 +1615,9 @@
                 Missing page title
               </a>
             </th>
+            <td class="error">
+              Issue found
+            </td>
             <td class="error">
               Issue found
             </td>
@@ -1603,6 +1700,9 @@
             <td class="warning">
               Warning only
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -1647,6 +1747,9 @@
             <td class="warning">
               Warning only
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -1655,6 +1758,9 @@
                 Text formatting used instead of an actual heading
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -1735,6 +1841,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
 
@@ -1781,6 +1890,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -1789,6 +1901,9 @@
                 List not marked up as a list
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -1869,6 +1984,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -1912,6 +2030,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -1959,6 +2080,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -2003,6 +2127,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -2031,6 +2158,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -2091,6 +2221,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -2131,6 +2264,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="error">
+              Issue found
             </td>
             <td class="error">
               Issue found
@@ -2179,6 +2315,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -2213,6 +2352,9 @@
             </td>
             <td class="warning">
               Warning only
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -2267,6 +2409,9 @@
             <td class="warning">
               Warning only
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -2310,6 +2455,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -2355,6 +2503,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -2363,6 +2514,9 @@
                 Table with some empty cells
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -2445,6 +2599,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -2489,6 +2646,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -2497,6 +2657,9 @@
                 Image with no alt attribute
               </a>
             </th>
+            <td class="error">
+              Issue found
+            </td>
             <td class="error">
               Issue found
             </td>
@@ -2577,6 +2740,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="manual">
+              User to check
+            </td>
           </tr>
         
           <tr>
@@ -2620,6 +2786,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="error">
+              Issue found
             </td>
           </tr>
         
@@ -2665,6 +2834,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -2699,6 +2871,9 @@
             </td>
             <td class="warning">
               Warning only
+            </td>
+            <td class="manual">
+              User to check
             </td>
             <td class="manual">
               User to check
@@ -2753,6 +2928,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="manual">
+              User to check
+            </td>
           </tr>
         
           <tr>
@@ -2797,6 +2975,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="manual">
+              User to check
+            </td>
           </tr>
         
           <tr>
@@ -2837,6 +3018,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="manual">
+              User to check
             </td>
             <td class="manual">
               User to check
@@ -2887,6 +3071,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -2895,6 +3082,9 @@
                 Flashing content doesn&#39;t have warning
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -2975,6 +3165,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
 
@@ -3014,6 +3207,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="error">
+              Issue found
             </td>
             <td class="error">
               Issue found
@@ -3065,6 +3261,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="manual">
+              User to check
+            </td>
           </tr>
         
           <tr>
@@ -3108,6 +3307,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -3153,6 +3355,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="warning">
+              Warning only
+            </td>
           </tr>
         
           <tr>
@@ -3161,6 +3366,9 @@
                 Links not separated by printable characters
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -3241,6 +3449,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -3275,6 +3486,9 @@
             </td>
             <td class="warning">
               Warning only
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -3329,6 +3543,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -3354,6 +3571,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -3417,6 +3637,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="manual">
+              User to check
+            </td>
           </tr>
         
           <tr>
@@ -3457,6 +3680,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="error">
+              Issue found
             </td>
             <td class="error">
               Issue found
@@ -3505,6 +3731,9 @@
             <td class="warning">
               Warning only
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -3549,6 +3778,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -3589,6 +3821,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -3637,6 +3872,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -3677,6 +3915,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -3725,6 +3966,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -3759,6 +4003,9 @@
             </td>
             <td class="warning">
               Warning only
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -3813,6 +4060,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -3857,6 +4107,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
 
@@ -3867,6 +4120,9 @@
                 Image button has no alt attribute
               </a>
             </th>
+            <td class="error">
+              Issue found
+            </td>
             <td class="error">
               Issue found
             </td>
@@ -3947,6 +4203,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="identified">
+              Noticed but not a fail
+            </td>
           </tr>
         
           <tr>
@@ -3991,6 +4250,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="manual">
+              User to check
+            </td>
           </tr>
         
           <tr>
@@ -4001,6 +4263,9 @@
             </th>
             <td class="notfound">
               Not found
+            </td>
+            <td class="error">
+              Issue found
             </td>
             <td class="error">
               Issue found
@@ -4081,6 +4346,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="manual">
+              User to check
+            </td>
           </tr>
         
           <tr>
@@ -4118,6 +4386,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="error">
+              Issue found
             </td>
             <td class="error">
               Issue found
@@ -4169,6 +4440,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -4203,6 +4477,9 @@
             </td>
             <td class="warning">
               Warning only
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -4257,6 +4534,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -4294,6 +4574,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="error">
+              Issue found
             </td>
             <td class="error">
               Issue found
@@ -4345,6 +4628,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -4389,6 +4675,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="identified">
+              Noticed but not a fail
+            </td>
           </tr>
         
           <tr>
@@ -4426,6 +4715,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="error">
+              Issue found
             </td>
             <td class="error">
               Issue found
@@ -4477,6 +4769,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -4521,6 +4816,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -4555,6 +4853,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -4609,6 +4910,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -4652,6 +4956,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -4697,6 +5004,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -4722,6 +5032,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -4785,6 +5098,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -4828,6 +5144,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -4873,6 +5192,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
 
@@ -4883,6 +5205,9 @@
                 Inadequately-sized clickable targets found
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -4965,6 +5290,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -5008,6 +5336,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -5053,6 +5384,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -5096,6 +5430,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="warning">
+              Warning only
             </td>
           </tr>
         
@@ -5141,6 +5478,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -5149,6 +5489,9 @@
                 Keyboard focus assigned to a non focusable element using tabindex=0
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -5229,6 +5572,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -5272,6 +5618,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -5317,6 +5666,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -5325,6 +5677,9 @@
                 Lightbox - ESC key doesn&#39;t close the lightbox
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -5405,6 +5760,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -5448,6 +5806,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -5493,6 +5854,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -5501,6 +5865,9 @@
                 Lightbox - focus is not moved immediately to lightbox
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -5581,6 +5948,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -5624,6 +5994,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -5671,6 +6044,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -5696,6 +6072,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -5761,6 +6140,9 @@
             <td class="manual">
               User to check
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -5805,6 +6187,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -5813,6 +6198,9 @@
                 visibility:hidden used to visually hide content when it should be available to screenreader
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -5893,6 +6281,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -5936,6 +6327,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
           </tr>
         
@@ -5983,6 +6377,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -6023,6 +6420,9 @@
             </td>
             <td class="manual">
               User to check
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -6071,6 +6471,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="identified">
+              Noticed but not a fail
+            </td>
           </tr>
         
           <tr>
@@ -6114,6 +6517,9 @@
             </td>
             <td class="notfound">
               Not found
+            </td>
+            <td class="warning">
+              Warning only
             </td>
           </tr>
         
@@ -6159,6 +6565,9 @@
             <td class="error">
               Issue found
             </td>
+            <td class="error">
+              Issue found
+            </td>
           </tr>
         
           <tr>
@@ -6172,6 +6581,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -6247,6 +6659,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -6255,6 +6670,9 @@
                 Inline style adds colour
               </a>
             </th>
+            <td class="notfound">
+              Not found
+            </td>
             <td class="notfound">
               Not found
             </td>
@@ -6335,6 +6753,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="notfound">
+              Not found
+            </td>
           </tr>
         
           <tr>
@@ -6348,6 +6769,9 @@
             </td>
             <td class="error">
               Issue found
+            </td>
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -6423,6 +6847,9 @@
             <td class="notfound">
               Not found
             </td>
+            <td class="warning">
+              Warning only
+            </td>
           </tr>
         
 
@@ -6433,6 +6860,13 @@
   <h2 id="changelog">Changelog</h2>
 
   <ol class="summary-data">
+    
+      <li>
+        <time class="timestamp">13 February 2018</time>
+        
+          <a href="https://github.com/alphagov/accessibility-tool-audit/pull/34">Added new tool: ASLint</a>
+        
+      </li>
     
       <li>
         <time class="timestamp">13 February 2018</time>

--- a/tests.json
+++ b/tests.json
@@ -14,7 +14,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Plain language is not used": {
@@ -31,7 +32,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Content is not in correct reading order in source code": {
@@ -48,7 +50,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Content is not organised into well-defined groups or chunks, using headings, lists, and other visual mechanisms": {
@@ -65,7 +68,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "First instance of abbreviation not expanded": {
@@ -82,7 +86,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     }
   },
@@ -101,7 +106,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     }
   },
@@ -120,7 +126,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "manual"
       }
     },
     "Small text does not have a contrast ratio of at least 4.5:1 so does not meet AA": {
@@ -137,7 +144,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "Large text does not have a contrast ratio of at least 3:1 so does not meet AA": {
@@ -154,7 +162,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Small text does not have a contrast ratio of at least 7:1 so does not meet AAA": {
@@ -171,7 +180,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "Large text does not have a contrast ratio of at least 4.5:1 so does not meet AAA": {
@@ -188,7 +198,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Focus not visible": {
@@ -205,7 +216,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     }
   },
@@ -224,7 +236,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "All caps text found": {
@@ -241,7 +254,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "warning"
       }
     },
     "Blink element found": {
@@ -258,7 +272,8 @@
         "eiii": "error",
         "nu": "error",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "warning"
       }
     },
     "Italics used on long sections of text": {
@@ -275,7 +290,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "warning"
       }
     },
     "Marquee element found": {
@@ -292,7 +308,8 @@
         "eiii": "error",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "Long lines of text": {
@@ -309,7 +326,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Very small text found": {
@@ -326,7 +344,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "error"
       }
     },
     "Justified text found": {
@@ -343,7 +362,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     }
   },
@@ -362,7 +382,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "html element has an empty lang attribute": {
@@ -379,7 +400,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "lang attribute not used to identify change of language": {
@@ -396,7 +418,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Text language is in the wrong direction": {
@@ -413,7 +436,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "html element has an invalid value in the lang attribute": {
@@ -430,7 +454,8 @@
         "eiii": "error",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "lang attribute used to identify change of language, but with invalid value": {
@@ -447,7 +472,8 @@
         "eiii": "notfound",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "html element is missing a lang attribute": {
@@ -464,7 +490,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "html element has lang attribute set to wrong language": {
@@ -481,7 +508,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "lang attribute used to identify change of language, but with wrong language": {
@@ -498,7 +526,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     }
   },
@@ -517,7 +546,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Empty page title": {
@@ -534,7 +564,8 @@
         "eiii": "error",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Missing page title": {
@@ -551,7 +582,8 @@
         "eiii": "error",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     }
   },
@@ -570,7 +602,8 @@
         "eiii": "error",
         "nu": "warning",
         "siteimprove": "error",
-        "fae": "warning"
+        "fae": "warning",
+        "aslint": "error"
       }
     },
     "Missing H1": {
@@ -587,7 +620,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "warning"
+        "fae": "warning",
+        "aslint": "error"
       }
     },
     "Text formatting used instead of an actual heading": {
@@ -604,7 +638,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Headings not structured in a hierarchical manner": {
@@ -621,7 +656,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     }
   },
@@ -640,7 +676,8 @@
         "eiii": "notfound",
         "nu": "error",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "List not marked up as a list": {
@@ -657,7 +694,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "DT or DD elements that are not contained within a DL element": {
@@ -674,7 +712,8 @@
         "eiii": "notfound",
         "nu": "error",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Improperly nested lists": {
@@ -691,7 +730,8 @@
         "eiii": "notfound",
         "nu": "error",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     }
   },
@@ -710,7 +750,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "manual",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "Table has no scope attributes": {
@@ -727,7 +768,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Table nested within table header": {
@@ -744,7 +786,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Table nested within table": {
@@ -761,7 +804,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Table has no table headings": {
@@ -778,7 +822,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Table with inconsistent numbers of columns in rows": {
@@ -795,7 +840,8 @@
         "eiii": "notfound",
         "nu": "error",
         "siteimprove": "manual",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Table that only has TH elements in it": {
@@ -812,7 +858,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Table is missing a caption": {
@@ -829,7 +876,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "warning"
+        "fae": "warning",
+        "aslint": "error"
       }
     },
     "Table used for layout": {
@@ -846,7 +894,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Table has an empty table header": {
@@ -863,7 +912,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Table with some empty cells": {
@@ -880,7 +930,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     }
   },
@@ -899,7 +950,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Image with presentation role has non-empty alt": {
@@ -916,7 +968,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Image with no alt attribute": {
@@ -933,7 +986,8 @@
         "eiii": "error",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Background image that conveys information does not have a text alternative": {
@@ -950,7 +1004,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "manual"
       }
     },
     "Image has empty alt and non-empty title": {
@@ -967,7 +1022,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "error"
       }
     },
     "A distraction is present, an animated gif": {
@@ -984,7 +1040,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Image that conveys information has an empty alt attribute": {
@@ -1001,7 +1058,8 @@
         "eiii": "notfound",
         "nu": "manual",
         "siteimprove": "manual",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "manual"
       }
     },
     "Image that conveys information has inappropriate alt text": {
@@ -1018,7 +1076,8 @@
         "eiii": "notfound",
         "nu": "manual",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "manual"
       }
     },
     "Image alt attribute contains image file name": {
@@ -1035,7 +1094,8 @@
         "eiii": "notfound",
         "nu": "manual",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "manual"
       }
     },
     "Image with partial text alternative": {
@@ -1052,7 +1112,8 @@
         "eiii": "notfound",
         "nu": "manual",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "manual"
       }
     }
   },
@@ -1071,7 +1132,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "manual",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "error"
       }
     },
     "Flashing content doesn't have warning": {
@@ -1088,7 +1150,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Embedded audio file is missing text alternative": {
@@ -1105,7 +1168,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "manual",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     }
   },
@@ -1124,7 +1188,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Link to javascript, invalid hypertext reference": {
@@ -1141,7 +1206,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "manual"
       }
     },
     "Uninformative link text": {
@@ -1158,7 +1224,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Link launches new window with no warning": {
@@ -1175,7 +1242,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "warning"
       }
     },
     "Links not separated by printable characters": {
@@ -1192,7 +1260,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Link text with identical title": {
@@ -1209,7 +1278,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Links to a sound file, no transcript": {
@@ -1226,7 +1296,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Identifying links by colour alone": {
@@ -1243,7 +1314,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Link to PDF does not include information on file format and file size": {
@@ -1260,7 +1332,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Link to #, invalid hypertext reference": {
@@ -1277,7 +1350,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "manual"
       }
     },
     "Blank link text": {
@@ -1294,7 +1368,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Links with the same text go to different pages": {
@@ -1311,7 +1386,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "warning"
+        "fae": "warning",
+        "aslint": "notfound"
       }
     },
     "Link text does not make sense out of context": {
@@ -1328,7 +1404,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Adjacent links going to the same destination": {
@@ -1345,7 +1422,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Link contains only a full stop": {
@@ -1362,7 +1440,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Image link alt text repeats text in the link": {
@@ -1379,7 +1458,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Link not clearly identifiable and distinguishable from surrounding text": {
@@ -1396,7 +1476,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Link to a multimedia file, no transcript": {
@@ -1413,7 +1494,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Non-specific link text": {
@@ -1430,7 +1512,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "error"
       }
     },
     "Link to an image, no text alternative": {
@@ -1447,7 +1530,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     }
   },
@@ -1466,7 +1550,8 @@
         "eiii": "error",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Empty button": {
@@ -1483,7 +1568,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "identified"
       }
     },
     "Uninformative alt attribute value on image button": {
@@ -1500,7 +1586,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "manual"
       }
     },
     "Empty alt attribute on image button": {
@@ -1517,7 +1604,8 @@
         "eiii": "error",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     }
   },
@@ -1536,7 +1624,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "manual"
       }
     },
     "Labels missing when they would look clumsy for some form controls": {
@@ -1553,7 +1642,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Error messages - no suggestion for corrections given, e.g. required format": {
@@ -1570,7 +1660,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Left aligned form labels with too much white space": {
@@ -1587,7 +1678,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Group of radio buttons not enclosed in a fieldset": {
@@ -1604,7 +1696,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Form element has no label": {
@@ -1621,7 +1714,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Fieldset without a legend": {
@@ -1638,7 +1732,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "Empty legend": {
@@ -1655,7 +1750,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "identified"
       }
     },
     "Label element with for= attribute but not matching id= attribute of form control": {
@@ -1672,7 +1768,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Group of check boxes not enclosed in a fieldset": {
@@ -1689,7 +1786,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "error"
       }
     },
     "Empty label found": {
@@ -1706,7 +1804,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Two unique labels, but identical for= attributes": {
@@ -1723,7 +1822,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Errors identified with a poor colour contrast": {
@@ -1740,7 +1840,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Non-unique field label found": {
@@ -1757,7 +1858,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "Missing labels in checkboxes": {
@@ -1774,7 +1876,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Field hint not associated with input": {
@@ -1791,7 +1894,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Placeholder no label": {
@@ -1808,7 +1912,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Errors are not identified": {
@@ -1825,7 +1930,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Form control that changes context without warning": {
@@ -1842,7 +1948,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     }
   },
@@ -1861,7 +1968,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     }
   },
@@ -1880,7 +1988,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "manual",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Lightbox - close button doesn't receive focus": {
@@ -1897,7 +2006,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "Focus order in wrong order": {
@@ -1914,7 +2024,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "manual",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Tabindex greater than 0": {
@@ -1931,7 +2042,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "manual",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "warning"
       }
     },
     "Keyboard focus is not indicated visually": {
@@ -1948,7 +2060,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "error"
       }
     },
     "Keyboard focus assigned to a non focusable element using tabindex=0": {
@@ -1965,7 +2078,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Concertina items don't get keyboard focus": {
@@ -1982,7 +2096,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     },
     "Keyboard trap": {
@@ -1999,7 +2114,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Dropdown navigation - only the top level items receive focus": {
@@ -2016,7 +2132,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Lightbox - ESC key doesn't close the lightbox": {
@@ -2033,7 +2150,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Link with a role=button does not work with space bar": {
@@ -2050,7 +2168,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "manual",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "error"
       }
     },
     "Tooltips don't receive keyboard focus": {
@@ -2067,7 +2186,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Accesskey attribute used": {
@@ -2084,7 +2204,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Lightbox - focus is not moved immediately to lightbox": {
@@ -2101,7 +2222,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Lightbox - focus is not retained within the lightbox": {
@@ -2118,7 +2240,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Fake button is not keyboard accessible": {
@@ -2135,7 +2258,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "notfound"
       }
     }
   },
@@ -2154,7 +2278,8 @@
         "eiii": "error",
         "nu": "notfound",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "iframe title attribute does not describe the content or purpose of the iframe": {
@@ -2171,7 +2296,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     }
   },
@@ -2190,7 +2316,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     },
     "Non-decorative content inserted using CSS": {
@@ -2207,7 +2334,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "visibility:hidden used to visually hide content when it should be available to screenreader": {
@@ -2224,7 +2352,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "display:none used to visually hide content when it should be available to screenreader": {
@@ -2241,7 +2370,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Page zoom - boxes that don't expand with the text": {
@@ -2258,7 +2388,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "manual"
+        "fae": "manual",
+        "aslint": "notfound"
       }
     }
   },
@@ -2277,7 +2408,8 @@
         "eiii": "error",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "error"
       }
     },
     "Article element used to mark-up an element that's not an article/blog post etc.": {
@@ -2294,7 +2426,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "manual",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Empty paragraph": {
@@ -2311,7 +2444,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "identified"
       }
     },
     "Deprecated center element": {
@@ -2328,7 +2462,8 @@
         "eiii": "notfound",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "warning"
       }
     },
     "Invalid ARIA role names": {
@@ -2345,7 +2480,8 @@
         "eiii": "notfound",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "error"
+        "fae": "error",
+        "aslint": "error"
       }
     },
     "Object not embedded accessibly - wmode parameter not set to window": {
@@ -2362,7 +2498,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Spacer image found": {
@@ -2379,7 +2516,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Inline style adds colour": {
@@ -2396,7 +2534,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Start and close tags don't match": {
@@ -2413,7 +2552,8 @@
         "eiii": "notfound",
         "nu": "error",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "PRE element without CODE element inside it": {
@@ -2430,7 +2570,8 @@
         "eiii": "notfound",
         "nu": "notfound",
         "siteimprove": "notfound",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "notfound"
       }
     },
     "Deprecated font element": {
@@ -2447,7 +2588,8 @@
         "eiii": "notfound",
         "nu": "error",
         "siteimprove": "error",
-        "fae": "notfound"
+        "fae": "notfound",
+        "aslint": "warning"
       }
     }
   }

--- a/tools-info.md
+++ b/tools-info.md
@@ -19,6 +19,7 @@ Try to use all the most inquisitive options. This is a list of options per tool 
 * Nu Html Checker: add image report
 * Siteimprove: choose AAA conformance, select error and warning and review severity
 * FAE: default (except it's recommended to uncheck 'include pass and n/a results' for better readability)
+* ASLint: default
 
 
 ## Changelogs
@@ -37,3 +38,4 @@ To know if a tool was updated since we last tested it, check these changelogs:
 * [Nu Html Checker changelog](https://github.com/validator/validator/releases)
 * Siteimprove doesn't have a changelog, but their [Siteimprove Chrome extension](https://chrome.google.com/webstore/detail/siteimprove-accessibility/efcfolpjihicnikpmhnmphjhhpiclljc) lists a version number and a date when it was last updated
 * [FAE changelog](https://fae.disability.illinois.edu/abouts/versions/)
+* ASLint doesn't have a changelog, but the footer of the visible UI lists a version number and a date when it was last updated


### PR DESCRIPTION
I tested [ASLint](https://www.aslint.org/) with its bookmarklet on 19 January 2018 with version 0.0.999 (updated: 13.1.2018).
This is now the 13th tool in the audit, it comes in at (tied) 6th place with 28% of issues found.

I did not pass most of the colour contrast checks due to a [bug in ASLint](https://github.com/ctomczyk/aslint/issues/10) which "found" colour contrast issues in every single element.