### PR TITLE
Update test results for Tenon

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -9,8 +9,8 @@
       "identified": 0
     },
     "tenon": {
-      "notfound": 90,
-      "error": 50,
+      "notfound": 94,
+      "error": 46,
       "error_paid": 0,
       "warning": 2,
       "manual": 0,
@@ -107,11 +107,11 @@
   },
   "totals": {
     "total": 142,
-    "detectable": 122,
-    "undetectable": 20
+    "detectable": 121,
+    "undetectable": 21
   },
   "percentages": {
-    "detectable": 86,
+    "detectable": 85,
     "tools": {
       "google": {
         "detectable": {
@@ -125,18 +125,18 @@
       },
       "tenon": {
         "detectable": {
-          "error_warning": 43,
-          "error_warning_manual": 43
+          "error_warning": 40,
+          "error_warning_manual": 40
         },
         "total": {
-          "error_warning": 37,
-          "error_warning_manual": 37
+          "error_warning": 34,
+          "error_warning_manual": 34
         }
       },
       "wave": {
         "detectable": {
           "error_warning": 32,
-          "error_warning_manual": 34
+          "error_warning_manual": 35
         },
         "total": {
           "error_warning": 27,
@@ -146,7 +146,7 @@
       "codesniffer": {
         "detectable": {
           "error_warning": 26,
-          "error_warning_manual": 39
+          "error_warning_manual": 40
         },
         "total": {
           "error_warning": 23,
@@ -156,7 +156,7 @@
       "axe": {
         "detectable": {
           "error_warning": 34,
-          "error_warning_manual": 35
+          "error_warning_manual": 36
         },
         "total": {
           "error_warning": 29,
@@ -226,7 +226,7 @@
       "fae": {
         "detectable": {
           "error_warning": 33,
-          "error_warning_manual": 58
+          "error_warning_manual": 59
         },
         "total": {
           "error_warning": 28,
@@ -256,8 +256,8 @@
       {
         "position": 2,
         "name": "tenon",
-        "error_warning": 37,
-        "error_warning_manual": 37
+        "error_warning": 34,
+        "error_warning_manual": 34
       },
       {
         "position": 3,
@@ -347,27 +347,27 @@
       },
       {
         "position": 4,
-        "name": "tenon",
-        "error_warning": 37,
-        "error_warning_manual": 37
-      },
-      {
-        "position": 5,
         "name": "siteimprove",
         "error_warning": 29,
         "error_warning_manual": 36
       },
       {
-        "position": 6,
+        "position": 5,
         "name": "aslint",
         "error_warning": 28,
         "error_warning_manual": 35
       },
       {
-        "position": 7,
+        "position": 6,
         "name": "achecker",
         "error_warning": 31,
         "error_warning_manual": 35
+      },
+      {
+        "position": 7,
+        "name": "tenon",
+        "error_warning": 34,
+        "error_warning_manual": 34
       },
       {
         "position": 8,

--- a/changelog.json
+++ b/changelog.json
@@ -3,6 +3,11 @@
   "changelog": [
     {
       "date": "13 February 2018",
+      "text": "Re-tested and updated 7 results on Tenon",
+      "link": "https://github.com/alphagov/accessibility-tool-audit/pull/36"
+    },
+    {
+      "date": "13 February 2018",
       "text": "Added new tool: ASLint",
       "link": "https://github.com/alphagov/accessibility-tool-audit/pull/35"
     },

--- a/changelog.json
+++ b/changelog.json
@@ -4,7 +4,7 @@
     {
       "date": "13 February 2018",
       "text": "Added new tool: ASLint",
-      "link": "https://github.com/alphagov/accessibility-tool-audit/pull/34"
+      "link": "https://github.com/alphagov/accessibility-tool-audit/pull/35"
     },
     {
       "date": "13 February 2018",

--- a/index.html
+++ b/index.html
@@ -77,8 +77,8 @@
               <td>40%</td>
             </tr><tr>
               <th><a href="https://tenon.io/">Tenon</a></th>
-              <td>37%</td>
-              <td>37%</td>
+              <td>34%</td>
+              <td>34%</td>
             </tr><tr>
               <th><a href="http://achecker.ca/">AChecker</a></th>
               <td>31%</td>

--- a/results.html
+++ b/results.html
@@ -1146,8 +1146,8 @@
             <td class="error">
               Issue found
             </td>
-            <td class="notfound">
-              Not found
+            <td class="error">
+              Issue found
             </td>
             <td class="notfound">
               Not found
@@ -2235,8 +2235,8 @@
             <td class="error">
               Issue found
             </td>
-            <td class="error">
-              Issue found
+            <td class="warning">
+              Warning only
             </td>
             <td class="manual">
               User to check
@@ -3463,8 +3463,8 @@
             <td class="notfound">
               Not found
             </td>
-            <td class="warning">
-              Warning only
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -6058,8 +6058,8 @@
             <td class="notfound">
               Not found
             </td>
-            <td class="error">
-              Issue found
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -6438,8 +6438,8 @@
             <td class="notfound">
               Not found
             </td>
-            <td class="error">
-              Issue found
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -6485,8 +6485,8 @@
             <td class="notfound">
               Not found
             </td>
-            <td class="error">
-              Issue found
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -6814,8 +6814,8 @@
             <td class="notfound">
               Not found
             </td>
-            <td class="error">
-              Issue found
+            <td class="notfound">
+              Not found
             </td>
             <td class="notfound">
               Not found
@@ -6864,7 +6864,14 @@
       <li>
         <time class="timestamp">13 February 2018</time>
         
-          <a href="https://github.com/alphagov/accessibility-tool-audit/pull/34">Added new tool: ASLint</a>
+          <a href="https://github.com/alphagov/accessibility-tool-audit/pull/36">Re-tested and updated 7 results on Tenon</a>
+        
+      </li>
+    
+      <li>
+        <time class="timestamp">13 February 2018</time>
+        
+          <a href="https://github.com/alphagov/accessibility-tool-audit/pull/35">Added new tool: ASLint</a>
         
       </li>
     

--- a/tests.json
+++ b/tests.json
@@ -391,7 +391,7 @@
       "results": {
         "google": "error",
         "asqatasun": "error",
-        "tenon": "notfound",
+        "tenon": "error",
         "wave": "notfound",
         "sortsite": "error",
         "axe": "error",
@@ -813,7 +813,7 @@
       "results": {
         "google": "error",
         "asqatasun": "manual",
-        "tenon": "error",
+        "tenon": "warning",
         "wave": "manual",
         "sortsite": "error",
         "axe": "error",
@@ -1287,7 +1287,7 @@
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
-        "tenon": "warning",
+        "tenon": "notfound",
         "wave": "notfound",
         "sortsite": "notfound",
         "axe": "notfound",
@@ -2287,7 +2287,7 @@
       "results": {
         "google": "notfound",
         "asqatasun": "manual",
-        "tenon": "error",
+        "tenon": "notfound",
         "wave": "notfound",
         "sortsite": "notfound",
         "axe": "notfound",
@@ -2435,7 +2435,7 @@
       "results": {
         "google": "notfound",
         "asqatasun": "notfound",
-        "tenon": "error",
+        "tenon": "notfound",
         "wave": "notfound",
         "sortsite": "notfound",
         "axe": "notfound",
@@ -2453,7 +2453,7 @@
       "results": {
         "google": "notfound",
         "asqatasun": "error",
-        "tenon": "error",
+        "tenon": "notfound",
         "wave": "notfound",
         "sortsite": "error",
         "axe": "notfound",
@@ -2579,7 +2579,7 @@
       "results": {
         "google": "notfound",
         "asqatasun": "error",
-        "tenon": "error",
+        "tenon": "notfound",
         "wave": "notfound",
         "sortsite": "error",
         "axe": "notfound",


### PR DESCRIPTION
I've re-tested Tenon on 5 February 2018 with the January 2018 version.
This results in a change to 7 tests and a decrease from 37% to 34% of barriers found. But Tenon still keeps its second place.

