### PR TITLE
Fix gulp primordials error

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "nunjucks": "^3.1.3"
   },
   "resolutions": {
-    "graceful-fs": "4.2.3"
+    "graceful-fs": "^4.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "preinstall": "npx npm-force-resolutions"
   },
   "author": "",
   "license": "ISC",
@@ -16,5 +17,8 @@
     "gulp-sass": "^3.2.1",
     "lodash": "^4.17.10",
     "nunjucks": "^3.1.3"
+  },
+  "resolutions": {
+    "graceful-fs": "4.2.3"
   }
 }


### PR DESCRIPTION
When running `gulp` I get the following error

```
% gulp
fs.js:39
} = primordials;
    ^

ReferenceError: primordials is not defined
    at fs.js:39:5
    at req_ (.../accessibility-tool-audit/node_modules/natives/index.js:143:24)
    at Object.req [as require] (.../accessibility-tool-audit/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (.../accessibility-tool-audit/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (internal/modules/cjs/loader.js:1147:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
    at Module.load (internal/modules/cjs/loader.js:996:32)
    at Function.Module._load (internal/modules/cjs/loader.js:896:14)
    at Module.require (internal/modules/cjs/loader.js:1036:19)
    at require (internal/modules/cjs/helpers.js:72:18)
```

This is an an issue with gulp 3 and nodejs 12.

The fix is to use npm-force-resolutions. Credit to [Valentin on Stack Overflow](https://stackoverflow.com/a/58394828) for describing the general issue and the fix.