### PR TITLE
Update 2021 ASLint

### DIFF
--- a/tests.json
+++ b/tests.json
@@ -51,7 +51,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Content is not organised into well-defined groups or chunks, using headings, lists, and other visual mechanisms": {
@@ -69,7 +69,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "error"
       }
     },
     "First instance of abbreviation not expanded": {
@@ -127,7 +127,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "manual",
-        "aslint": "manual"
+        "aslint": "error"
       }
     },
     "Small text does not have a contrast ratio of at least 4.5:1 so does not meet AA": {
@@ -217,7 +217,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "manual",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     }
   },
@@ -255,7 +255,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "warning"
+        "aslint": "error"
       }
     },
     "Blink element found": {
@@ -273,7 +273,7 @@
         "nu": "error",
         "siteimprove": "notfound",
         "fae": "manual",
-        "aslint": "warning"
+        "aslint": "error"
       }
     },
     "Italics used on long sections of text": {
@@ -291,7 +291,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "warning"
+        "aslint": "error"
       }
     },
     "Marquee element found": {
@@ -309,7 +309,7 @@
         "nu": "error",
         "siteimprove": "error",
         "fae": "error",
-        "aslint": "notfound"
+        "aslint": "error"
       }
     },
     "Long lines of text": {
@@ -437,7 +437,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "error"
       }
     },
     "html element has an invalid value in the lang attribute": {
@@ -603,7 +603,7 @@
         "nu": "warning",
         "siteimprove": "error",
         "fae": "warning",
-        "aslint": "error"
+        "aslint": "notfound"
       }
     },
     "Missing H1": {
@@ -639,7 +639,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Headings not structured in a hierarchical manner": {
@@ -1151,7 +1151,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Embedded audio file is missing text alternative": {
@@ -1207,7 +1207,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "manual"
+        "aslint": "error"
       }
     },
     "Uninformative link text": {
@@ -1243,7 +1243,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "warning"
+        "aslint": "error"
       }
     },
     "Links not separated by printable characters": {
@@ -1315,7 +1315,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "manual",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Link to PDF does not include information on file format and file size": {
@@ -1387,7 +1387,7 @@
         "nu": "notfound",
         "siteimprove": "error",
         "fae": "warning",
-        "aslint": "notfound"
+        "aslint": "error"
       }
     },
     "Link text does not make sense out of context": {
@@ -1423,7 +1423,7 @@
         "nu": "notfound",
         "siteimprove": "error",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "error"
       }
     },
     "Link contains only a full stop": {
@@ -1459,7 +1459,7 @@
         "nu": "notfound",
         "siteimprove": "error",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "error"
       }
     },
     "Link not clearly identifiable and distinguishable from surrounding text": {
@@ -1477,7 +1477,7 @@
         "nu": "notfound",
         "siteimprove": "error",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Link to a multimedia file, no transcript": {
@@ -1569,7 +1569,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "error",
-        "aslint": "identified"
+        "aslint": "notfound"
       }
     },
     "Uninformative alt attribute value on image button": {
@@ -1587,7 +1587,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "manual"
+        "aslint": "error"
       }
     },
     "Empty alt attribute on image button": {
@@ -1751,7 +1751,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "error",
-        "aslint": "identified"
+        "aslint": "notfound"
       }
     },
     "Label element with for= attribute but not matching id= attribute of form control": {
@@ -1823,7 +1823,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "error"
       }
     },
     "Errors identified with a poor colour contrast": {
@@ -1969,7 +1969,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     }
   },
@@ -2007,7 +2007,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "error",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Focus order in wrong order": {
@@ -2025,7 +2025,7 @@
         "nu": "notfound",
         "siteimprove": "manual",
         "fae": "manual",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Tabindex greater than 0": {
@@ -2043,7 +2043,7 @@
         "nu": "notfound",
         "siteimprove": "manual",
         "fae": "notfound",
-        "aslint": "warning"
+        "aslint": "error"
       }
     },
     "Keyboard focus is not indicated visually": {
@@ -2061,7 +2061,7 @@
         "nu": "notfound",
         "siteimprove": "error",
         "fae": "manual",
-        "aslint": "error"
+        "aslint": "manual"
       }
     },
     "Keyboard focus assigned to a non focusable element using tabindex=0": {
@@ -2097,7 +2097,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "error",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Keyboard trap": {
@@ -2115,7 +2115,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "manual",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Dropdown navigation - only the top level items receive focus": {
@@ -2133,7 +2133,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Lightbox - ESC key doesn't close the lightbox": {
@@ -2151,7 +2151,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Link with a role=button does not work with space bar": {
@@ -2187,7 +2187,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "manual",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Accesskey attribute used": {
@@ -2223,7 +2223,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Lightbox - focus is not retained within the lightbox": {
@@ -2241,7 +2241,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Fake button is not keyboard accessible": {
@@ -2259,7 +2259,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "error",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     }
   },
@@ -2279,7 +2279,7 @@
         "nu": "notfound",
         "siteimprove": "error",
         "fae": "error",
-        "aslint": "error"
+        "aslint": "notfound"
       }
     },
     "iframe title attribute does not describe the content or purpose of the iframe": {
@@ -2317,7 +2317,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "manual",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "Non-decorative content inserted using CSS": {
@@ -2335,7 +2335,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "notfound"
+        "aslint": "manual"
       }
     },
     "visibility:hidden used to visually hide content when it should be available to screenreader": {
@@ -2445,7 +2445,7 @@
         "nu": "notfound",
         "siteimprove": "notfound",
         "fae": "notfound",
-        "aslint": "identified"
+        "aslint": "notfound"
       }
     },
     "Deprecated center element": {
@@ -2463,7 +2463,7 @@
         "nu": "error",
         "siteimprove": "error",
         "fae": "notfound",
-        "aslint": "warning"
+        "aslint": "error"
       }
     },
     "Invalid ARIA role names": {
@@ -2589,7 +2589,7 @@
         "nu": "error",
         "siteimprove": "error",
         "fae": "notfound",
-        "aslint": "warning"
+        "aslint": "error"
       }
     }
   }


### PR DESCRIPTION
Hi @selfthinker 

As you can see on the last pull request I have been playing around with the commits, sorry for that. I now want to make a single PR per tool and all base them of the current existing repo. In this manner you can add the tools one by one in any desired order or even not add them. If I added them all in a single PR one commit I think it would have been more work. If I am wrong you are more then welcome to tell me :D.

For the ASLint update the two main changes are: I set every warning to error. It because I didnt see any difference between warning and error in the tool. The only difference I did spot is that 3 layers if interface down there is a severity level which I didn't experience as a real difference between either a warning or error. I'll leave it up to you as maintainers to make the decision on how to register them. Also some of the results were labelled to "identified" since no specific output was generated by the tool while running the related testcases I considered this feature removed. 

Kind Regards, 